### PR TITLE
Fix example usage snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Here is an example of running this command with the sample state/block files in 
   -oracleBlockHeaderFile "./data/deneb_goerli_block_header_7431952.json" \
   -stateFile "./data/deneb_goerli_slot_7431952.json" \
   -validatorIndex 200240 \
-  -outputFile "withdrawal_proof_302913.json" \
+  -outputFile "withdrawal_proof_200240.json" \
   -chainID 5 \
   -historicalSummariesIndex 271 \
   -blockHeaderIndex 8191 \

--- a/README.md
+++ b/README.md
@@ -19,30 +19,78 @@ $cd ..
 ### Generate Validator Withdrawal Credential Proof
 Here is the command:
 ```
-$ ./generation/generation -command ValidatorFieldsProof -oracleBlockHeaderFile [ORACLE_BLOCK_HEADER_FILE_PATH] -stateFile [STATE_FILE_PATH]-validatorIndex [VALIDATOR_INDEX] -outputFile [OUTPUT_FILE_PATH] -chainID [CHAIN_ID]
+$ ./generation/generation \
+    -command ValidatorFieldsProof \
+    -oracleBlockHeaderFile [ORACLE_BLOCK_HEADER_FILE_PATH] \
+    -stateFile [STATE_FILE_PATH] \
+    -validatorIndex [VALIDATOR_INDEX] \
+    -outputFile [OUTPUT_FILE_PATH] \
+    -chainID [CHAIN_ID]
 ```
 Here is an example of running this command with the sample state/block files in the `/data` folder
 ```
-./generation/generation -command ValidatorFieldsProof -oracleBlockHeaderFile "../data/goerli_block_header_6399998.json" -stateFile "../data/goerli_slot_6399998.json" -validatorIndex 302913 -outputFile "withdrawal_credential_proof_302913.json" -chainID 5
+./generation/generation \
+  -command ValidatorFieldsProof \
+  -oracleBlockHeaderFile "./data/deneb_goerli_block_header_7431952.json" \
+  -stateFile "./data/deneb_goerli_slot_7431952.json" \
+  -validatorIndex 302913 \
+  -outputFile "withdrawal_credential_proof_302913.json" \
+  -chainID 5
 ```
 ### Generate Withdrawal Proof
 Here is the command:
 ```
-$ ./generation/generation -command WithdrawalFieldsProof -oracleBlockHeaderFile [ORACLE_BLOCK_HEADER_FILE_PATH] -stateFile [STATE_FILE_PATH]-validatorIndex [VALIDATOR_INDEX] -outputFile [OUTPUT_FILE_PATH] -chainID [CHAIN_ID] -historicalSummariesIndex [HISTORICAL_SUMMARIES_INDEX] -blockHeaderIndex [BLOCK_HEADER_INDEX] -historicalSummaryStateFile [HISTORICAL_SUMMARY_STATE_FILE_PATH] -blockHeaderFile [BLOCK_HEADER_FILE_PATH] -blockBodyFile [BLOCK_BODY_FILE_PATH] -withdrawalIndex [WITHDRAWAL_INDEX]
+$ ./generation/generation \
+  -command WithdrawalFieldsProof \
+  -oracleBlockHeaderFile [ORACLE_BLOCK_HEADER_FILE_PATH] \
+  -stateFile [STATE_FILE_PATH] \
+  -validatorIndex [VALIDATOR_INDEX] \
+  -outputFile [OUTPUT_FILE_PATH] \
+  -chainID [CHAIN_ID] \
+  -historicalSummariesIndex [HISTORICAL_SUMMARIES_INDEX] \
+  -blockHeaderIndex [BLOCK_HEADER_INDEX] \
+  -historicalSummaryStateFile [HISTORICAL_SUMMARY_STATE_FILE_PATH] \
+  -blockHeaderFile [BLOCK_HEADER_FILE_PATH] \
+  -blockBodyFile [BLOCK_BODY_FILE_PATH] \
+  -withdrawalIndex [WITHDRAWAL_INDEX]
 ```
 Here is an example of running this command with the sample state/block files in the `/data` folder
 
 ```
-./generation/generation -command WithdrawalFieldsProof -oracleBlockHeaderFile "../data/goerli_block_header_6399998.json" -stateFile "../data/goerli_slot_6399998.json" -validatorIndex 200240 -outputFile "withdrawal_proof_302913.json" -chainID 5 -historicalSummariesIndex 146 -blockHeaderIndex 8092 -historicalSummaryStateFile "../data/goerli_slot_6397852.json" -blockHeaderFile  "../data/goerli_block_header_6397852.json" -blockBodyFile "../data/goerli_block_6397852.json" -withdrawalIndex 0
+./generation/generation \
+  -command WithdrawalFieldsProof \
+  -oracleBlockHeaderFile "./data/deneb_goerli_block_header_7431952.json" \
+  -stateFile "./data/deneb_goerli_slot_7431952.json" \
+  -validatorIndex 200240 \
+  -outputFile "withdrawal_proof_302913.json" \
+  -chainID 5 \
+  -historicalSummariesIndex 271 \
+  -blockHeaderIndex 8191 \
+  -historicalSummaryStateFile "./data/goerli_slot_6397852.json" \
+  -blockHeaderFile  "./data/goerli_block_header_6397852.json" \
+  -blockBodyFile "./data/goerli_block_6397852.json" \
+  -withdrawalIndex 0
 ```
 
 ### Generate a Balance Update Proof.  
 ```
-$ ./generation/generation "BalanceUpdateProof"  -oracleBlockHeaderFile [ORACLE_BLOCK_HEADER_FILE_PATH] -stateFile [STATE_FILE_PATH]-validatorIndex [VALIDATOR_INDEX] -outputFile [OUTPUT_FILE_PATH] -chainID [CHAIN_ID]
+$ ./generation/generation \
+  - command BalanceUpdateProof \
+  -oracleBlockHeaderFile [ORACLE_BLOCK_HEADER_FILE_PATH] \
+  -stateFile [STATE_FILE_PATH] \
+  -validatorIndex [VALIDATOR_INDEX] \
+  -outputFile [OUTPUT_FILE_PATH] \
+  -chainID [CHAIN_ID]
 ```
 Here is an example of running this command with the sample state/block files in the `/data` folder:
 ```
-./generation/generation -command BalanceUpdateProof -oracleBlockHeaderFile "../data/goerli_block_header_6399998.json" -stateFile "../data/goerli_slot_6399998.json" -validatorIndex 302913 -outputFile "withdrawal_credential_proof_302913.json" -chainID 5
+./generation/generation \
+  -command BalanceUpdateProof \
+  -oracleBlockHeaderFile "./data/deneb_goerli_block_header_7431952.json" \
+  -stateFile "./data/deneb_goerli_slot_7431952.json" \
+  -validatorIndex 302913 \
+  -outputFile "withdrawal_credential_proof_302913.json" \
+  -chainID 5
 ```
 
 # Proof Generation Input Glossary


### PR DESCRIPTION
This PR makes it so that developers may copy/paste the example usage snippets to confirm that the CLI is able to successfully generate proofs.

The *Withdrawal Proof* snippet is not working because of the issue described [here](https://github.com/Layr-Labs/eigenpod-proofs-generation/issues/7#issuecomment-1923297961).