### PR TITLE
[Readme + Question]: initialize PR to fix issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,17 +108,17 @@ Here is a breakdown of the inputs here:
   ```
   (withdrawal_slot - FIRST_CAPELLA_SLOT) // SLOTS_PER_HISTORICAL_ROOT
   ```
-  where `FIRST_CAPELLA_SLOT` on mainnet is 6209536 and `SLOTS_PER_HISTORICAL_ROOT` is 8192. Note that `withdrawal_slot` is the slot number of the block containing the withdrawal you want to prove.
+  where `FIRST_CAPELLA_SLOT` on [Mainnet](https://twitter.com/TimBeiko/status/1755597708520501672) is 6209536, 5193728 on [Goerli](https://twitter.com/TimBeiko/status/1633554636711034880), 950272 on [Hoelsky](https://blog.ethereum.org/2024/01/24/sepolia-holesky-dencun) and `SLOTS_PER_HISTORICAL_ROOT` is 8192. Note that `withdrawal_slot` is the slot number of the block containing the withdrawal you want to prove.
 - "blockHeaderIndex" -  this is the blockheaderRoot's index within the historical summaries entry, which can be calculated like this:
   ```
-  withdrawal_slot mod SLOTS_PER_HISTORICAL_ROOT
+  SLOTS_PER_HISTORICAL_ROOT - 1
   ```
 
 - "historicalSummaryStateFile" This is the beacon state at the slot such that:
-historical_summary_state.slot = `SLOTS_PER_HISTORICAL_ROOT` * (withdrawal_slot // `SLOTS_PER_HISTORICAL_ROOT`) + 1.
+historical_summary_state.slot = `SLOTS_PER_HISTORICAL_ROOT` * ((withdrawal_slot // `SLOTS_PER_HISTORICAL_ROOT`) + 1).
 
-- blockHeaderFile  - blockHeader from the withdrawal slot
-- blockBodyFile" Is the block body file from the withdrawal slot
+- blockHeaderFile  - blockHeader from the withdrawal slot, is such that: `historical_summary_state.slot` - 1
+- blockBodyFile" Is the block body file from the withdrawal slot, is such that `historical_summary_state.slot` - 1
 - withdrawalIndex Is the index of the withdrawal within the block (between 0 and 15)
 
 
@@ -168,9 +168,4 @@ Here is an example of running this command with the sample state/block files in 
 
 # What Are Historical Summary Proofs?
 Every block contains 16 withdrawals and any given beacon state stores the last 8192 block roots.  Thus if a withdrawal was within the last 8192 blocks, we can prove any withdrawal against one of the block roots, and then prove that block root against the state root.  However, what happens when we need to prove something from further in the past than 8192 blocks? That is where historical summaries come in. 
-	Every 8192 blocks, the state transition function takes a “snapshot” of the state.block_roots that are stored in the beacon state by taking the hash tree root of the state.block_roots, and adding that root to state.historical_summaries.  Then, state.block_roots is cleared and the next 8192 block_roots will be added to state.block_roots.  Thus, to prove an old withdrawal, we need to take the extra step of retrieving the state at the slot at which the snapshot that contains the root of the block when the withdrawal was included. Refer [here](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#historicalsummary) for the beacon chain specs for historical summaries. 
-
-
-
-
-
+	Every 8192 blocks, the state transition function takes a “snapshot” of the state.block_roots that are stored in the beacon state by taking the hash tree root of the state.block_roots, and adding that root to state.historical_summaries.  Then, state.block_roots is cleared and the next 8192 block_roots will be added to state.block_roots.  Thus, to prove an old withdrawal, we need to take the extra step of retrieving the state at the slot at which the snapshot that contains the root of the block when the withdrawal was included. Refer [here](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#historicalsummary) for the beacon chain specs for historical summaries.


### PR DESCRIPTION
# Overview
In the process of trying to re-compute the proof in the example for `goerli`, I ran into multiple issues in calculating the same values that are provided in the example. If the example is the ground truth for correctness in what needs to get passed as parameters, then the calculations provided in the `README.md` file are incorrect. The example I am referring is the following, which can also be found [here](https://github.com/Layr-Labs/eigenpod-proofs-generation?tab=readme-ov-file#generate-withdrawal-proof):
```
./generation/generation \
  -command WithdrawalFieldsProof \
  -oracleBlockHeaderFile ./data/deneb_goerli_block_header_7431952.json \
  -stateFile ./data/deneb_goerli_slot_7431952.json \
  -validatorIndex 627559 \
  -outputFile full_withdrawal_proof_627559.json \
  -chainID 5 \
  -historicalSummariesIndex 271 \
  -blockHeaderIndex 8191 \
  -historicalSummaryStateFile ./data/deneb_goerli_slot_7421952.json \
  -blockHeaderFile  data/deneb_goerli_block_header_7421951.json \
  -blockBodyFile data/deneb_goerli_block_7421951.json \
  -withdrawalIndex 0
  ```

# Re-calculation of indexes details
In recalculating the indexes to compute the proof I have used the following information
-  5193728 goerli capela fork (verified [here](https://twitter.com/TimBeiko/status/1633554636711034880))

The following calculations are taking place in the `slot_number` described in the example : `slot_number` = `7431952` on Goerli Testnet (chainID = 5)

## historicalSummaryStateFile
Using the equation listed in the original `README` file for computing this value I get the following:

`8192 * (slot_number/8192) -1` = `7430143` which is the incorrect index (compared to the example).

To get the correct index, the following modification needs to be made to the equation:
```
historical_summary_state.slot = `SLOTS_PER_HISTORICAL_ROOT` * ((withdrawal_slot // `SLOTS_PER_HISTORICAL_ROOT`) + 1)
```
Once this modification is made the result matches up:
`8192 * (slot_number//8192 - 1)` = `7421952` (as seen in the example)

## blockHeaderIndex
When trying to recalculate this index using the `mod` operation or `%`, I get the following:
`MOD(slot_number,8192)` = `1808`  which is the incorrect index (compared to the example).

To get the correct index, the following modification needs to be made to the equation:
```
  SLOTS_PER_HISTORICAL_ROOT - 1
```

Once this modification is made the result matches up:
`8192 -1` = `8191` (as seen in the example)

## historicalSummariesIndex
When trying to recalculate this index using the prescribed equation I get the following:
`(slot_number -  5193732)//8192` =  `273` which is the incorrect index (compared to the example).

I am not sure how to get the correct index, which in the provided example is 271. It seems that by inspection it could be:
```
(SLOT_NUMBER -  FIRST_CAPELLA_SLOT)/SLOTS_PER_HISTORICAL_ROOT - 2
```
Although I am not sure if this continues to be correct once looking at other `slot_numbers`.
**Please advise here**

For the rest of the indexes here... **blockHeaderFile** and **blockBodyFile** by inspection it appears that they are 
defined as such:
```
historical_summary_state.slot - 1
```

But please do confirm this as well.