### PR TITLE
More explicit error messages when working with json beacon state

### DIFF
--- a/generation/proof_utils.go
+++ b/generation/proof_utils.go
@@ -292,14 +292,14 @@ func ParseDenebStateJSONFile(filePath string) (*beaconStateJSONDeneb, error) {
 	data, err := ioutil.ReadFile(filePath)
 
 	if err != nil {
-		log.Debug().Str("file", filePath).Msg("error with reading file")
+		log.Debug().Str("file", filePath).Msg("error with reading beaconState file")
 		return nil, err
 	}
 
 	var beaconState beaconStateVersionDeneb
 	err = json.Unmarshal(data, &beaconState)
 	if err != nil {
-		log.Debug().Msg("error with JSON unmarshalling")
+		log.Debug().Msg("error with beaconState JSON unmarshalling")
 		return nil, err
 	}
 
@@ -311,14 +311,14 @@ func ParseCapellaStateJSONFile(filePath string) (*beaconStateJSONCapella, error)
 	data, err := ioutil.ReadFile(filePath)
 
 	if err != nil {
-		log.Debug().Str("file", filePath).Msg("error with reading file")
+		log.Debug().Str("file", filePath).Msg("error with reading beaconState file")
 		return nil, err
 	}
 
 	var beaconState beaconStateVersionCapella
 	err = json.Unmarshal(data, &beaconState)
 	if err != nil {
-		log.Debug().Msg("error with JSON unmarshalling")
+		log.Debug().Msg("error with beaconState JSON unmarshalling")
 		return nil, err
 	}
 

--- a/proof_utils.go
+++ b/proof_utils.go
@@ -160,7 +160,7 @@ func ParseJSONFileDeneb(filePath string) (*beaconStateJSONDeneb, error) {
 	data, err := os.ReadFile(filePath)
 
 	if err != nil {
-		fmt.Println("error with reading file")
+		fmt.Println("error with reading beaconState file")
 		return nil, err
 	}
 
@@ -179,7 +179,7 @@ func ParseJSONFileCapella(filePath string) (*beaconStateJSONCapella, error) {
 	data, err := os.ReadFile(filePath)
 
 	if err != nil {
-		fmt.Println("error with reading file")
+		fmt.Println("error with reading beaconState file")
 		return nil, err
 	}
 
@@ -324,14 +324,14 @@ func ParseDenebStateJSONFile(filePath string) (*beaconStateJSONDeneb, error) {
 	data, err := ioutil.ReadFile(filePath)
 
 	if err != nil {
-		log.Debug().Str("file", filePath).Msg("error with reading file")
+		log.Debug().Str("file", filePath).Msg("error with reading beaconState file")
 		return nil, err
 	}
 
 	var beaconState beaconStateVersionDeneb
 	err = json.Unmarshal(data, &beaconState)
 	if err != nil {
-		log.Debug().Msg("error with JSON unmarshalling")
+		log.Debug().Msg("error with beaconState JSON unmarshalling")
 		return nil, err
 	}
 
@@ -343,14 +343,14 @@ func ParseCapellaStateJSONFile(filePath string) (*beaconStateJSONCapella, error)
 	data, err := ioutil.ReadFile(filePath)
 
 	if err != nil {
-		log.Debug().Str("file", filePath).Msg("error with reading file")
+		log.Debug().Str("file", filePath).Msg("error with reading beaconState file")
 		return nil, err
 	}
 
 	var beaconState beaconStateVersionCapella
 	err = json.Unmarshal(data, &beaconState)
 	if err != nil {
-		log.Debug().Msg("error with JSON unmarshalling")
+		log.Debug().Msg("error with beaconState JSON unmarshalling")
 		return nil, err
 	}
 


### PR DESCRIPTION
`error with JSON unmarshalling` is too ambiguous given that there is more than 1 file can be supplied