### PR TITLE
[Minor fix]: historicalSummaryStateSlot > oracleBlockHeaderSlot check

### DIFF
--- a/generation/generate_withdrawal_fields_proof.go
+++ b/generation/generate_withdrawal_fields_proof.go
@@ -63,6 +63,11 @@ func GenerateWithdrawalFieldsProof(
 	}
 	ParseDenebBeaconStateFromJSON(*historicalSummaryJSON, &historicalSummaryState)
 
+	if uint64(historicalSummaryState.Slot) >= uint64(oracleBeaconBlockHeader.Slot) {
+		log.Debug().Msg("GenerateWithdrawalFieldsProof: historical summary slot is greater than oracle block header slot")
+		return nil
+	}
+
 	withdrawalBlockHeader, err = ExtractBlockHeader(blockHeaderFile)
 	if err != nil {
 		log.Debug().AnErr("GenerateWithdrawalFieldsProof: error with parsing header file", err)


### PR DESCRIPTION
## Description

If `historicalSummaryStateSlot` > `oracleBlockHeaderSlot` then proof should not be able to be generated, since the `oracleBlockHeaderSlot` needs to always be >= `historicalSummaryStateSlot`.