### PR TITLE
fixes for withdrawal credential command

### DIFF
--- a/tx_submitoor/tx_submitter/chain_client.go
+++ b/tx_submitoor/tx_submitter/chain_client.go
@@ -31,7 +31,7 @@ type ChainClient struct {
 	Contracts          map[common.Address]*bind.BoundContract
 }
 
-func NewChainClient(ethClient *ethclient.Client, privateKeyString string) (*ChainClient, error) {
+func NewChainClient(ethClient *ethclient.Client, privateKeyString string, address string, gasPrice int64, gasLimit uint64) (*ChainClient, error) {
 	var (
 		accountAddress common.Address
 		privateKey     *ecdsa.PrivateKey
@@ -63,7 +63,18 @@ func NewChainClient(ethClient *ethclient.Client, privateKeyString string) (*Chai
 		if err != nil {
 			return nil, fmt.Errorf("NewClient: cannot create NoSendTransactOpts: %w", err)
 		}
-		opts.NoSend = true
+		opts.NoSend = false
+	} else {
+		opts = &bind.TransactOpts{
+			From: common.HexToAddress(address),
+			Signer: func(a common.Address, t *types.Transaction) (*types.Transaction, error) {
+				return t, nil
+			},
+			Context:  context.Background(),
+			NoSend:   true,
+			GasPrice: big.NewInt(gasPrice),
+			GasLimit: gasLimit,
+		}
 	}
 
 	c := &ChainClient{

--- a/tx_submitoor/tx_submitter/submit_withdrawal_credential_proof.go
+++ b/tx_submitoor/tx_submitter/submit_withdrawal_credential_proof.go
@@ -107,7 +107,7 @@ func (u *EigenPodProofTxSubmitter) SubmitVerifyWithdrawalCredentialsTx(withdrawa
 		return nil, err
 	}
 
-	if !submitTransaction {
+	if submitTransaction {
 		_, err = u.chainClient.EstimateGasPriceAndLimitAndSendTx(ctx, withdrawalCredentialsTx, "withdraw")
 		if err != nil {
 			return nil, fmt.Errorf("failed to execute withdrawal transaction: %w", err)


### PR DESCRIPTION
Changes:
- fix struct tags for env variables
- fix flag parsing for commands
- fix default transactionOpts when not signing with a private key