### PR TITLE
submitoor withdrawal proof fix

### DIFF
--- a/prove_withdrawal.go
+++ b/prove_withdrawal.go
@@ -2,6 +2,7 @@ package eigenpodproofs
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"time"
 
@@ -237,6 +238,10 @@ func (epp *EigenPodProofs) ProveWithdrawal(
 
 		withdrawals = withdrawalBlock.Deneb.Message.Body.ExecutionPayload.Withdrawals
 		withdrawalIndex = GetWithdrawalIndex(validatorIndex, withdrawals)
+		if withdrawalIndex == math.MaxUint64 {
+			slot, _ = withdrawalBlock.Slot()
+			return nil, nil, errors.New(fmt.Sprintf("Couldn't find withdrawal index for validator %d in the slot %d", validatorIndex, slot))
+		}
 		withdrawalFields = ConvertWithdrawalToWithdrawalFields(withdrawalBlock.Deneb.Message.Body.ExecutionPayload.Withdrawals[withdrawalIndex])
 		timestamp = withdrawalBlock.Deneb.Message.Body.ExecutionPayload.Timestamp
 	} else if withdrawalBlock.Version == spec.DataVersionCapella {
@@ -258,6 +263,10 @@ func (epp *EigenPodProofs) ProveWithdrawal(
 
 		withdrawals = withdrawalBlock.Capella.Message.Body.ExecutionPayload.Withdrawals
 		withdrawalIndex = GetWithdrawalIndex(validatorIndex, withdrawals)
+		if withdrawalIndex == math.MaxUint64 {
+			slot, _ = withdrawalBlock.Slot()
+			return nil, nil, errors.New(fmt.Sprintf("Couldn't find withdrawal index for validator %d in the slot %d", validatorIndex, slot))
+		}
 		withdrawalFields = ConvertWithdrawalToWithdrawalFields(withdrawalBlock.Capella.Message.Body.ExecutionPayload.Withdrawals[withdrawalIndex])
 
 		timestamp = withdrawalBlock.Capella.Message.Body.ExecutionPayload.Timestamp

--- a/tx_submitoor/tx_submitter/submit_withdrawal_proof.go
+++ b/tx_submitoor/tx_submitter/submit_withdrawal_proof.go
@@ -140,10 +140,10 @@ func (u *EigenPodProofTxSubmitter) SubmitVerifyAndProcessWithdrawalsTx(withdrawa
 	}
 
 	withdrawalBlocks := make([]*spec.VersionedSignedBeaconBlock, 0)
-	for _, file := range cfg.WithdrawalDetails.WithdrawalBlockHeaderFiles {
+	for _, file := range cfg.WithdrawalDetails.WithdrawalBlockBodyFiles {
 		block, err := commonutils.ExtractBlock(file)
 		if err != nil {
-			log.Debug().AnErr("Error with parsing header file", err)
+			log.Debug().AnErr("Error with parsing block file", err)
 			return nil, err
 		}
 		versionedSignedBlock, err := beacon.CreateVersionedSignedBlock(block)


### PR DESCRIPTION
It was using the array of header files instead of blocks bodies

+ handle error when the provided validatorId isn't in the withdrawal slot with the relevant error message