### PR TITLE
Fix calldata encoding in generated withdrawal proof calldata

### DIFF
--- a/tx_submitoor/main.go
+++ b/tx_submitoor/main.go
@@ -63,7 +63,7 @@ func main() {
 		if err != nil {
 			log.Panic().Msgf("failed to submit withdrawal proof: %s", err)
 		}
-		log.Info().Msgf("Withdrawal proof submitted with calldata: %s", calldata)
+		log.Info().Msgf("Withdrawal proof submitted with calldata: %s", hex.EncodeToString(calldata))
 
 	case "WithdrawalCredentialProof":
 		calldata, err := submitter.SubmitVerifyWithdrawalCredentialsTx(*withdrawalProofConfigFile, *submitTransaction)


### PR DESCRIPTION
Before `Withdrawal credential proof submitted with calldata: \ufffdQ\ufffdR\0000sdfsdf\0000\0000\0000\0000\0000\0000s4fldsfjsd\0000......`

After `Withdrawal credential proof submitted with calldata: e251ef520000000.......`