### PR TITLE
Adds commands to generate multiple proofs at once and manage cache

### DIFF
--- a/generation/cache_utils.go
+++ b/generation/cache_utils.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+)
+
+// Cache represents a file-based cache system for storing byte arrays.
+type Cache struct {
+	FilePath string
+}
+
+// NewCache creates a new cache with a specified file path.
+func NewCache(filePath string) *Cache {
+	return &Cache{FilePath: filePath}
+}
+
+func DeleteCache(filePath string) error {
+	return os.Remove(filePath)
+}
+
+// Set writes a byte array to the cache file.
+func (c *Cache) Set(data []byte) error {
+	// Write the data to the file, setting the permissions to 0644.
+	err := os.WriteFile(c.FilePath, data, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Get reads the byte array from the cache file.
+func (c *Cache) Get() ([]byte, error) {
+	// Read the data from the file.
+	data, err := os.ReadFile(c.FilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return data, nil
+}

--- a/generation/custom_flag_types.go
+++ b/generation/custom_flag_types.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type IntSlice struct {
+	slice []uint64
+}
+
+func (i *IntSlice) String() string {
+	return fmt.Sprintf("%v", i.slice)
+}
+
+func (i *IntSlice) GetSlice() []uint64 {
+	return i.slice
+}
+
+func (i *IntSlice) Set(value string) error {
+	// Split the string by commas if user passes a comma-separated list.
+	vals := strings.Split(value, ",")
+	for _, val := range vals {
+		trimmedVal := strings.TrimSpace(val)
+		if trimmedVal == "" {
+			continue
+		}
+		intVal, err := strconv.ParseUint(trimmedVal, 10, 64)
+		if err != nil {
+			return err
+		}
+		i.slice = append(i.slice, intVal)
+	}
+	return nil
+}

--- a/generation/generate_validator_proofs.go
+++ b/generation/generate_validator_proofs.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+
+	eigenpodproofs "github.com/Layr-Labs/eigenpod-proofs-generation"
+	beacon "github.com/Layr-Labs/eigenpod-proofs-generation/beacon"
+	commonutils "github.com/Layr-Labs/eigenpod-proofs-generation/common_utils"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+const tmpPath = "/tmp"
+
+func GenerateValidatorFieldsProofs(oracleBlockHeaderFile string, stateFile string, validatorIndices []uint64, chainID uint64, output string) error {
+
+	var oracleBeaconBlockHeader phase0.BeaconBlockHeader
+
+	oracleBeaconBlockHeader, err := commonutils.ExtractBlockHeader(oracleBlockHeaderFile)
+	if err != nil {
+		log.Debug().AnErr("Error with parsing header file", err)
+		return err
+	}
+
+	epp, err := eigenpodproofs.NewEigenPodProofs(chainID, 1000)
+	if err != nil {
+		log.Debug().AnErr("Error creating EPP object", err)
+		return err
+	}
+
+	versionedStatePtr, err := versionedStateUsingCache(stateFile, chainID, uint64(oracleBeaconBlockHeader.Slot))
+	if err != nil {
+		log.Debug().AnErr("Error with versionedStateUsingCache", err)
+		return err
+	}
+
+	var versionedState = *versionedStatePtr
+
+	// When a new CL version is released, this will break.
+	// original line (uses state directly):
+	//	beaconStateRoot, err := state.HashTreeRoot()
+	beaconStateRoot, err := versionedState.Deneb.HashTreeRoot()
+	if err != nil {
+		log.Debug().AnErr("Error with HashTreeRoot of state", err)
+		return err
+	}
+
+	validators, err := versionedState.Validators()
+	if err != nil {
+		log.Debug().AnErr("Error getting versioned Validators", err)
+		return err
+	}
+
+	allProofs := make([]commonutils.WithdrawalCredentialProofs, len(validatorIndices))
+	results := make(chan commonutils.WithdrawalCredentialProofs, len(validatorIndices))
+	var wg sync.WaitGroup
+
+	for _, validatorIndex := range validatorIndices {
+		wg.Add(1)
+		go func(index uint64) {
+			defer wg.Done()
+			stateRootProof, validatorFieldsProof, err := eigenpodproofs.ProveValidatorFields(epp, &oracleBeaconBlockHeader, &versionedState, index)
+			if err != nil {
+				log.Printf("Error with ProveValidatorFields for index %d: %v", index, err)
+				return
+			}
+
+			proof := commonutils.WithdrawalCredentialProofs{
+				StateRootAgainstLatestBlockHeaderProof: commonutils.ConvertBytesToStrings(stateRootProof.StateRootProof),
+				BeaconStateRoot:                        "0x" + hex.EncodeToString(beaconStateRoot[:]),
+				ValidatorIndex:                         index,
+				WithdrawalCredentialProof:              commonutils.ConvertBytesToStrings(validatorFieldsProof),
+				ValidatorFields:                        commonutils.GetValidatorFields(validators[index]),
+			}
+			results <- proof
+		}(validatorIndex)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	i := 0
+	for proof := range results {
+		allProofs[i] = proof
+		i++
+	}
+
+	if len(allProofs) != len(validatorIndices) {
+		numMissingProofs := len(validatorIndices) - len(allProofs)
+		err = errors.New(fmt.Sprintf("failed to generate %d proofs", numMissingProofs))
+		log.Debug().AnErr("missing proofs from results: ", err)
+		return err
+	}
+
+	proofData, err := json.Marshal(allProofs)
+	if err != nil {
+		log.Debug().AnErr("JSON marshal error: ", err)
+		return err
+	}
+
+	_ = os.WriteFile(output, proofData, 0644)
+
+	return nil
+}
+
+func stateCacheFilePath(chainID uint64, slot uint64) string {
+	return fmt.Sprintf("%s/versioned_state_chain_%d_slot_%d", tmpPath, chainID, slot)
+}
+
+/**
+ * Reading the state file and parsing the JSON can take several seconds. This uses a disk cache to store the parsed versioned state.
+ */
+func versionedStateUsingCache(stateFile string, chainID uint64, slot uint64) (*spec.VersionedBeaconState, error) {
+	var state deneb.BeaconState
+	var versionedState spec.VersionedBeaconState
+
+	versionedStateCache := NewCache(stateCacheFilePath(chainID, slot))
+	cachedVersionedState, err := versionedStateCache.Get()
+
+	if err != nil {
+		log.Debug().AnErr("Error fetching versionedState cache", err)
+	} else if cachedVersionedState != nil {
+		unmarshaledVersionedState, err := beacon.UnmarshalSSZVersionedBeaconState(cachedVersionedState)
+		if err != nil {
+			log.Debug().Msg("failed to unmarshal versioned beacon state")
+			return nil, err
+		}
+		versionedState = *unmarshaledVersionedState
+	}
+
+	if versionedState.IsEmpty() {
+		stateJSON, err := commonutils.ParseDenebStateJSONFile(stateFile)
+		if err != nil {
+			log.Debug().Msg("error with JSON parsing")
+			return nil, err
+		}
+
+		commonutils.ParseDenebBeaconStateFromJSON(*stateJSON, &state)
+
+		versionedState, err = beacon.CreateVersionedState(&state)
+		if err != nil {
+			log.Debug().AnErr("Error with CreateVersionedState", err)
+			return nil, err
+		}
+
+		ssz, err := beacon.MarshalSSZVersionedBeaconState(versionedState)
+		if err != nil {
+			log.Debug().AnErr("Error with caching versionedState", err)
+			return nil, err
+		}
+		versionedStateCache.Set(ssz)
+	}
+
+	return &versionedState, nil
+}
+
+func ClearStateCache(oracleBlockHeaderFile string, chainID uint64) error {
+	oracleBeaconBlockHeader, err := commonutils.ExtractBlockHeader(oracleBlockHeaderFile)
+	if err != nil {
+		log.Debug().AnErr("Error with parsing header file", err)
+		return err
+	}
+
+	err = DeleteCache(stateCacheFilePath(chainID, uint64(oracleBeaconBlockHeader.Slot)))
+	if err != nil {
+		log.Debug().AnErr("Failed to delete cache file", err)
+		return err
+	}
+	return nil
+}

--- a/generation/main.go
+++ b/generation/main.go
@@ -16,6 +16,10 @@ func main() {
 	// Defining flags for all the parameters
 	command := flag.String("command", "", "The command to execute")
 
+	// List of indexes is only used in GenerateValidatorFieldsProof
+	var validatorIndices IntSlice
+	flag.Var(&validatorIndices, "validatorIndices", "A list of validator indices separated by commas (e.g., -validatorIndices 1685702,1685703,1685704)")
+
 	oracleBlockHeaderFile := flag.String("oracleBlockHeaderFile", "", "Oracle block header file")
 	stateFile := flag.String("stateFile", "", "State file")
 	validatorIndex := flag.Uint64("validatorIndex", 0, "validatorIndex")
@@ -44,6 +48,14 @@ func main() {
 	switch *command {
 	case "ValidatorFieldsProof":
 		err = GenerateValidatorFieldsProof(*oracleBlockHeaderFile, *stateFile, *validatorIndex, *chainID, *outputFile)
+
+	// This command was implemented by Figment
+	case "ValidatorFieldsProofs":
+		err = GenerateValidatorFieldsProofs(*oracleBlockHeaderFile, *stateFile, validatorIndices.GetSlice(), *chainID, *outputFile)
+
+	// This command was implemented by Figment
+	case "ClearStateCache":
+		err = ClearStateCache(*oracleBlockHeaderFile, *chainID)
 
 	case "WithdrawalFieldsProof":
 		err = GenerateWithdrawalFieldsProof(*oracleBlockHeaderFile, *stateFile, *historicalSummaryStateFile, *blockHeaderFile, *blockBodyFile, *validatorIndex, *withdrawalIndex, *historicalSummariesIndex, *blockHeaderIndex, *chainID, *outputFile)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Layr-Labs/eigensdk-go v0.1.3
 	github.com/attestantio/go-eth2-client v0.19.9
 	github.com/caarlos0/env v3.5.0+incompatible
-	github.com/ethereum/go-ethereum v1.13.14
+	github.com/ethereum/go-ethereum v1.13.15
 	github.com/ferranbt/fastssz v0.1.3
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/minio/sha256-simd v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=
 github.com/ethereum/c-kzg-4844 v0.4.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
-github.com/ethereum/go-ethereum v1.13.14 h1:EwiY3FZP94derMCIam1iW4HFVrSgIcpsu0HwTQtm6CQ=
-github.com/ethereum/go-ethereum v1.13.14/go.mod h1:TN8ZiHrdJwSe8Cb6x+p0hs5CxhJZPbqB7hHkaUXcmIU=
+github.com/ethereum/go-ethereum v1.13.15 h1:U7sSGYGo4SPjP6iNIifNoyIAiNjrmQkz6EwQG+/EZWo=
+github.com/ethereum/go-ethereum v1.13.15/go.mod h1:TN8ZiHrdJwSe8Cb6x+p0hs5CxhJZPbqB7hHkaUXcmIU=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=


### PR DESCRIPTION
This introduces some additional commands to improve the speed at which validator proofs can be generated.

1. A proof for a single validator index requires loading and parsing the state. This implements a simple disk cache of the parsed state which saves ~10 seconds of execution time.
2. To clear the cache, there's a new command introduced.
3. There's also a new command introduced to generate proofs for multiple validator indexes in one call.

I don't necessarily expect this to be introduced into the official repo. I understand it's not a very clean implementation. However, these are some changes we're using to improve the speed at which proofs can be generated, and we wanted to share upstream.