### PR TITLE
Small fixes for re-use library as a service

### DIFF
--- a/common_utils/utils.go
+++ b/common_utils/utils.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"strconv"
@@ -60,7 +59,7 @@ type BalanceUpdateProofs struct {
 	ValidatorFields                        []string `json:"ValidatorFields"`
 }
 
-type beaconStateJSONDeneb struct {
+type BeaconStateJSONDeneb struct {
 	GenesisTime                  string                        `json:"genesis_time"`
 	GenesisValidatorsRoot        string                        `json:"genesis_validators_root"`
 	Slot                         string                        `json:"slot"`
@@ -123,7 +122,7 @@ type beaconStateJSONCapella struct {
 }
 
 type beaconStateVersionDeneb struct {
-	Data beaconStateJSONDeneb `json:"data"`
+	Data BeaconStateJSONDeneb `json:"data"`
 }
 
 type beaconStateVersionCapella struct {
@@ -149,7 +148,7 @@ type InputDataBlock struct {
 }
 
 func ConvertBytesToStrings(b [][32]byte) []string {
-	var s []string
+	s := make([]string, 0, len(b))
 	for _, v := range b {
 		s = append(s, "0x"+hex.EncodeToString(v[:]))
 	}
@@ -157,7 +156,7 @@ func ConvertBytesToStrings(b [][32]byte) []string {
 }
 
 func GetValidatorFields(v *phase0.Validator) []string {
-	var validatorFields []string
+	validatorFields := make([]string, 0, 8)
 	hh := ssz.NewHasher()
 
 	hh.PutBytes(v.PublicKey[:])
@@ -279,8 +278,8 @@ func GetWithdrawalIndex(validatorIndex uint64, withdrawals []*capella.Withdrawal
 	return math.MaxUint64
 }
 
-func ParseDenebStateJSONFile(filePath string) (*beaconStateJSONDeneb, error) {
-	data, err := ioutil.ReadFile(filePath)
+func ParseDenebStateJSONFile(filePath string) (*BeaconStateJSONDeneb, error) {
+	data, err := os.ReadFile(filePath)
 
 	if err != nil {
 		log.Debug().Str("file", filePath).Msgf("error with reading file: %v", err)
@@ -294,12 +293,11 @@ func ParseDenebStateJSONFile(filePath string) (*beaconStateJSONDeneb, error) {
 		return nil, err
 	}
 
-	actualData := beaconState.Data
-	return &actualData, nil
+	return &beaconState.Data, nil
 }
 
 func ParseCapellaStateJSONFile(filePath string) (*beaconStateJSONCapella, error) {
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 
 	if err != nil {
 		log.Debug().Str("file", filePath).Msgf("error with reading file: %v", err)
@@ -318,9 +316,7 @@ func ParseCapellaStateJSONFile(filePath string) (*beaconStateJSONCapella, error)
 }
 
 // nolint:gocyclo
-func ParseDenebBeaconStateFromJSON(data beaconStateJSONDeneb, s *deneb.BeaconState) error {
-	var err error
-
+func ParseDenebBeaconStateFromJSON(data *BeaconStateJSONDeneb, s *deneb.BeaconState) (err error) {
 	if data.GenesisTime == "" {
 		return errors.New("genesis time missing")
 	}

--- a/generation/generate_balance_update_proof.go
+++ b/generation/generate_balance_update_proof.go
@@ -22,7 +22,7 @@ func GenerateBalanceUpdateProof(oracleBlockHeaderFile string, stateFile string, 
 		log.Debug().AnErr("GenerateBalanceUpdateProof: error with JSON parsing", err)
 		return err
 	}
-	commonutils.ParseDenebBeaconStateFromJSON(*stateJSON, &state)
+	commonutils.ParseDenebBeaconStateFromJSON(stateJSON, &state)
 
 	oracleBeaconBlockHeader, err = commonutils.ExtractBlockHeader(oracleBlockHeaderFile)
 	if err != nil {

--- a/generation/generate_validator_proof.go
+++ b/generation/generate_validator_proof.go
@@ -22,7 +22,7 @@ func GenerateValidatorFieldsProof(oracleBlockHeaderFile string, stateFile string
 		log.Debug().Msg("GenerateValidatorFieldsProof: error with JSON parsing")
 		return err
 	}
-	commonutils.ParseDenebBeaconStateFromJSON(*stateJSON, &state)
+	commonutils.ParseDenebBeaconStateFromJSON(stateJSON, &state)
 
 	oracleBeaconBlockHeader, err = commonutils.ExtractBlockHeader(oracleBlockHeaderFile)
 	if err != nil {

--- a/generation/generate_withdrawal_fields_proof.go
+++ b/generation/generate_withdrawal_fields_proof.go
@@ -55,14 +55,14 @@ func GenerateWithdrawalFieldsProof(
 		log.Debug().AnErr("GenerateWithdrawalFieldsProof: error with JSON parsing state file", err)
 		return err
 	}
-	commonutils.ParseDenebBeaconStateFromJSON(*stateJSON, &state)
+	commonutils.ParseDenebBeaconStateFromJSON(stateJSON, &state)
 
 	historicalSummaryJSON, err := commonutils.ParseDenebStateJSONFile(historicalSummaryStateFile)
 	if err != nil {
 		log.Debug().AnErr("GenerateWithdrawalFieldsProof: error with JSON parsing historical summary state file", err)
 		return err
 	}
-	commonutils.ParseDenebBeaconStateFromJSON(*historicalSummaryJSON, &historicalSummaryState)
+	commonutils.ParseDenebBeaconStateFromJSON(historicalSummaryJSON, &historicalSummaryState)
 
 	withdrawalBlockHeader, err = commonutils.ExtractBlockHeader(blockHeaderFile)
 	if err != nil {

--- a/tx_submitoor/tx_submitter/submit_withdrawal_credential_proof.go
+++ b/tx_submitoor/tx_submitter/submit_withdrawal_credential_proof.go
@@ -93,7 +93,7 @@ func (u *EigenPodProofTxSubmitter) SubmitVerifyWithdrawalCredentialsTx(withdrawa
 		log.Debug().AnErr("GenerateWithdrawalFieldsProof: error with JSON parsing state file", err)
 		return nil, err
 	}
-	commonutils.ParseDenebBeaconStateFromJSON(*oracleStateJSON, &oracleState)
+	commonutils.ParseDenebBeaconStateFromJSON(oracleStateJSON, &oracleState)
 
 	versionedOracleState, err := beacon.CreateVersionedState(&oracleState)
 	if err != nil {

--- a/tx_submitoor/tx_submitter/submit_withdrawal_proof.go
+++ b/tx_submitoor/tx_submitter/submit_withdrawal_proof.go
@@ -122,7 +122,7 @@ func (u *EigenPodProofTxSubmitter) SubmitVerifyAndProcessWithdrawalsTx(withdrawa
 		log.Debug().AnErr("GenerateWithdrawalFieldsProof: error with JSON parsing state file", err)
 		return nil, err
 	}
-	commonutils.ParseDenebBeaconStateFromJSON(*oracleStateJSON, &oracleState)
+	commonutils.ParseDenebBeaconStateFromJSON(oracleStateJSON, &oracleState)
 
 	versionedOracleState, err := beacon.CreateVersionedState(&oracleState)
 
@@ -134,7 +134,7 @@ func (u *EigenPodProofTxSubmitter) SubmitVerifyAndProcessWithdrawalsTx(withdrawa
 			log.Debug().AnErr("GenerateWithdrawalFieldsProof: error with JSON parsing historical summary state file", err)
 			return nil, err
 		}
-		commonutils.ParseDenebBeaconStateFromJSON(*historicalSummaryStateJSON, &historicalSummaryState)
+		commonutils.ParseDenebBeaconStateFromJSON(historicalSummaryStateJSON, &historicalSummaryState)
 
 		historicalSummaryStateBlockRoots = append(historicalSummaryStateBlockRoots, historicalSummaryState.BlockRoots)
 	}


### PR DESCRIPTION
Hi there. Here are some small changes to the library to enable its use as part of a service

* BeaconStateJSONDeneb made to global object to re-use it
* ParseDenebBeaconStateFromJSON pass by pointer to avoid extra copy 
* slice without extra allocations