### PR TITLE
Use jsoniter in tx_submitoor to speedup the json parsing by ~25%

### DIFF
--- a/common_utils/utils.go
+++ b/common_utils/utils.go
@@ -2,8 +2,8 @@ package commonutils
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
+	jsoniter "github.com/json-iterator/go"
 	"io/ioutil"
 	"math"
 	"os"
@@ -202,8 +202,9 @@ func ExtractBlockHeader(blockHeaderFile string) (phase0.BeaconBlockHeader, error
 		return phase0.BeaconBlockHeader{}, err
 	}
 	// Decode JSON
+
 	var inputData InputDataBlockHeader
-	if err := json.Unmarshal(fileBytes, &inputData); err != nil {
+	if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(fileBytes, &inputData); err != nil {
 		return phase0.BeaconBlockHeader{}, err
 	}
 
@@ -218,7 +219,7 @@ func ExtractBlock(blockFile string) (deneb.BeaconBlock, error) {
 
 	// Decode JSON
 	var data InputDataBlock
-	if err := json.Unmarshal(fileBytes, &data); err != nil {
+	if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(fileBytes, &data); err != nil {
 		return deneb.BeaconBlock{}, err
 	}
 
@@ -234,7 +235,7 @@ func ExtractSignedDenebBlock(signedBlockFile string) (*spec.VersionedSignedBeaco
 
 	// Decode JSON
 	var data InputDataBlock
-	if err := json.Unmarshal(fileBytes, &data); err != nil {
+	if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(fileBytes, &data); err != nil {
 		return nil, err
 	}
 
@@ -288,7 +289,7 @@ func ParseDenebStateJSONFile(filePath string) (*beaconStateJSONDeneb, error) {
 	}
 
 	var beaconState beaconStateVersionDeneb
-	err = json.Unmarshal(data, &beaconState)
+	err = jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(data, &beaconState)
 	if err != nil {
 		log.Debug().Msgf("error with JSON unmarshalling: %v", err)
 		return nil, err
@@ -307,7 +308,7 @@ func ParseCapellaStateJSONFile(filePath string) (*beaconStateJSONCapella, error)
 	}
 
 	var beaconState beaconStateVersionCapella
-	err = json.Unmarshal(data, &beaconState)
+	err = jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(data, &beaconState)
 	if err != nil {
 		log.Debug().Msgf("error with JSON unmarshalling: %v", err)
 		return nil, err

--- a/generation/main.go
+++ b/generation/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
@@ -55,4 +54,5 @@ func main() {
 		log.Debug().Str("Unknown command:", *command)
 	}
 	log.Debug().AnErr("Error: ", err)
+
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/ethereum/go-ethereum v1.13.14
 	github.com/ferranbt/fastssz v0.1.3
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/json-iterator/go v1.1.12
 	github.com/minio/sha256-simd v1.0.1
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.31.0
@@ -41,6 +42,8 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,7 @@ github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOW
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb h1:PBC98N2aIaM3XXiurYmW7fx4GZkL8feAMVq7nEjURHk=
 github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
@@ -120,6 +121,8 @@ github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.16.0 h1:iULayQNOReoYUe+1qtKOqw9CwJv3aNQu8ivo7lw1HU4=
 github.com/klauspost/compress v1.16.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.2.6 h1:ndNyv040zDGIDh8thGkXYjnFtiN02M1PVVF+JE/48xc=
@@ -153,6 +156,10 @@ github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8oh
 github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -185,6 +192,7 @@ github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible/go
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=

--- a/tx_submitoor/main.go
+++ b/tx_submitoor/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/hex"
 	"flag"
+	"time"
 
 	eigenpodproofs "github.com/Layr-Labs/eigenpod-proofs-generation"
 	txsubmitter "github.com/Layr-Labs/eigenpod-proofs-generation/tx_submitoor/tx_submitter"
@@ -56,6 +57,8 @@ func main() {
 		*eigenPodProofs,
 	)
 
+	startedAt := time.Now()
+
 	// Handling commands based on the 'command' flag
 	switch *command {
 	case "WithdrawalFieldsProof":
@@ -76,6 +79,8 @@ func main() {
 		log.Debug().Str("Unknown command:", *command)
 	}
 	log.Debug().AnErr("Error: ", err)
+	log.Debug().Msgf("Took %f seconds", time.Since(startedAt).Seconds())
+
 }
 
 func parseConfig() Config {

--- a/tx_submitoor/tx_submitter/submit_withdrawal_proof.go
+++ b/tx_submitoor/tx_submitter/submit_withdrawal_proof.go
@@ -2,8 +2,8 @@ package txsubmitter
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	jsoniter "github.com/json-iterator/go"
 	"os"
 
 	"github.com/Layr-Labs/eigenpod-proofs-generation/beacon"
@@ -174,6 +174,7 @@ func parseWithdrawalProofConfig(filePath string) (*WithdrawalProofConfig, error)
 	}
 
 	var cfg WithdrawalProofConfig
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(data, &cfg)
 	if err != nil {
 		log.Debug().Msg("error with JSON unmarshalling")


### PR DESCRIPTION
The default json parser is relatively slow and it takes about 10s to parse 600Mb state file

This PR optimises json unmarshalling time by 25% simply by using more efficient library(1 line change) jsoniter as a dropin replacement.

Anecdotal benchmark for deposit proof generation for single validator on `Ryzen 5 PRO 5650U on Ubuntu 22.04`:
Before: **19.4s**
After: **15.1s**
Instant speedup: **~22.1%**