### PR TITLE
Fix bug in calculating `status` with no checkpoint active

### DIFF
--- a/cli/core/beaconClient.go
+++ b/cli/core/beaconClient.go
@@ -62,9 +62,12 @@ func (b *beaconClient) GetBeaconHeader(ctx context.Context, blockId string) (*v1
 }
 
 func (b *beaconClient) GetBeaconState(ctx context.Context, stateId string) (*spec.VersionedBeaconState, error) {
+	timeout, _ := time.ParseDuration("60s")
 	if provider, ok := b.eth2client.(eth2client.BeaconStateProvider); ok {
 		log.Info().Msgf("downloading beacon state %s", stateId)
-		opts := &api.BeaconStateOpts{State: stateId}
+		opts := &api.BeaconStateOpts{State: stateId, Common: api.CommonOpts{
+			Timeout: timeout,
+		}}
 		beaconState, err := provider.BeaconState(ctx, opts)
 		if err != nil {
 			return nil, err

--- a/cli/core/beaconClient.go
+++ b/cli/core/beaconClient.go
@@ -62,7 +62,7 @@ func (b *beaconClient) GetBeaconHeader(ctx context.Context, blockId string) (*v1
 }
 
 func (b *beaconClient) GetBeaconState(ctx context.Context, stateId string) (*spec.VersionedBeaconState, error) {
-	timeout, _ := time.ParseDuration("60s")
+	timeout, _ := time.ParseDuration("200s")
 	if provider, ok := b.eth2client.(eth2client.BeaconStateProvider); ok {
 		log.Info().Msgf("downloading beacon state %s", stateId)
 		opts := &api.BeaconStateOpts{State: stateId, Common: api.CommonOpts{

--- a/cli/core/status.go
+++ b/cli/core/status.go
@@ -125,13 +125,9 @@ func GetStatus(ctx context.Context, eigenpodAddress string, eth *ethclient.Clien
 	latestPodBalanceWei, err := eth.BalanceAt(ctx, common.HexToAddress(eigenpodAddress), nil)
 	PanicOnError("failed to fetch pod balance", err)
 	latestPodBalanceGwei := WeiToGwei(latestPodBalanceWei)
-	pendingGwei :=
-		new(big.Float).Sub(
-			new(big.Float).Add(
-				new(big.Float).SetUint64(uint64(sumRegularBalancesGwei)),
-				latestPodBalanceGwei),
-			new(big.Float).SetUint64(withdrawableRestakedExecutionLayerGwei),
-		)
+	pendingGwei := new(big.Float).Add(
+		new(big.Float).SetUint64(uint64(sumRegularBalancesGwei)),
+		latestPodBalanceGwei)
 	pendingEth := GweiToEther(pendingGwei)
 
 	return EigenpodStatus{

--- a/cli/main.go
+++ b/cli/main.go
@@ -123,7 +123,6 @@ func main() {
 
 							ital.Printf("\t%f new shares issued (%f ==> %f)\n", delta, startEther, endEther)
 						}
-
 					}
 					return nil
 				},


### PR DESCRIPTION
- Fix timeout for beacon state download (200s should be more than enough)
- Remove erroneous term from calculating the "after" state of running a checkpoint.