### PR TITLE
Allow checkpoint proofs to be submitted from file

### DIFF
--- a/cli/core/checkpoint.go
+++ b/cli/core/checkpoint.go
@@ -3,8 +3,10 @@ package core
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"math/big"
+	"os"
 	"strconv"
 
 	eigenpodproofs "github.com/Layr-Labs/eigenpod-proofs-generation"
@@ -13,6 +15,20 @@ import (
 )
 
 // , out, owner *string, forceCheckpoint bool
+func LoadCheckpointProofFromFile(path string) (*eigenpodproofs.VerifyCheckpointProofsCallParams, error) {
+	res := eigenpodproofs.VerifyCheckpointProofsCallParams{}
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(bytes, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
 
 func GenerateCheckpointProof(ctx context.Context, eigenpodAddress string, eth *ethclient.Client, chainId *big.Int, beaconClient BeaconClient) *eigenpodproofs.VerifyCheckpointProofsCallParams {
 	currentCheckpoint := GetCurrentCheckpoint(eigenpodAddress, eth)

--- a/cli/main.go
+++ b/cli/main.go
@@ -326,7 +326,7 @@ func main() {
 				Name:        "out",
 				Aliases:     []string{"O", "output"},
 				Value:       "",
-				Usage:       "Output `path` for the proof. (defaults to stdout)",
+				Usage:       "Output `path` for the proof. (defaults to stdout). NOTE: If `--out` is supplied along with `--owner`, `--out` takes precedence and the proof will not be broadcast.",
 				Destination: &output,
 			},
 			&cli.StringFlag{

--- a/cli/main.go
+++ b/cli/main.go
@@ -286,8 +286,6 @@ func main() {
 
 						color.Green("transaction: %s", txn.Hash().Hex())
 					} else {
-
-						// print to stdout.
 						data := map[string]any{
 							"validatorIndices": validatorIndices,
 							"validatorProofs":  validatorProofs,

--- a/cli/main.go
+++ b/cli/main.go
@@ -75,11 +75,7 @@ func main() {
 						color.NoColor = true
 					}
 
-					eth, err := ethclient.Dial(node)
-					core.PanicOnError("failed to reach eth --node.", err)
-
-					beaconClient, err := core.GetBeaconClient(beacon)
-					core.PanicOnError("failed to reach beacon chain.", err)
+					eth, beaconClient, _ := core.GetClients(ctx, node, beacon)
 
 					status := core.GetStatus(ctx, eigenpodAddress, eth, beaconClient)
 


### PR DESCRIPTION
<img width="1018" alt="image" src="https://github.com/Layr-Labs/eigenpod-proofs-generation/assets/2030176/18b6d5d7-b09c-4128-ab2a-6de2a4cdb7f7">

- Add `--proof checkpoint.json` as an argument to `checkpoint`, which allows the proof to be specified.
- Must also specify `--owner` to interact onchain, otherwise it'll throw an error.

Bypasses the normal flow and submits the proof immediately onchain.

NOTE:
- We don't support this for the other "credential" proof type, since you should just generate from latest beacon state anyways (if you fail to submit a proof, just make another one).

