### PR TITLE
Support Batching in CLI + Consent Messages

### DIFF
--- a/cli/core/checkpoint.go
+++ b/cli/core/checkpoint.go
@@ -27,7 +27,7 @@ func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, c
 
 	for i := 0; i < len(allProofChunks); i++ {
 		balanceProofs := allProofChunks[i]
-		txn, err := SubmitCheckpointProofBatch(owner, eigenpodAddress, chainId, proof, balanceProofs, eth)
+		txn, err := SubmitCheckpointProofBatch(owner, eigenpodAddress, chainId, proof.ValidatorBalancesRootProof, balanceProofs, eth)
 		if err != nil {
 			// failed to submit batch.
 			return transactions, err
@@ -42,7 +42,7 @@ func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, c
 	return transactions, nil
 }
 
-func SubmitCheckpointProofBatch(owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.VerifyCheckpointProofsCallParams, balanceProofs []*eigenpodproofs.BalanceProof, eth *ethclient.Client) (*types.Transaction, error) {
+func SubmitCheckpointProofBatch(owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.ValidatorBalancesRootProof, balanceProofs []*eigenpodproofs.BalanceProof, eth *ethclient.Client) (*types.Transaction, error) {
 	ownerAccount, err := PrepareAccount(&owner, chainId)
 	if err != nil {
 		return nil, err
@@ -56,10 +56,10 @@ func SubmitCheckpointProofBatch(owner, eigenpodAddress string, chainId *big.Int,
 	txn, err := eigenPod.VerifyCheckpointProofs(
 		ownerAccount.TransactionOptions,
 		onchain.BeaconChainProofsBalanceContainerProof{
-			BalanceContainerRoot: proof.ValidatorBalancesRootProof.ValidatorBalancesRoot,
-			Proof:                proof.ValidatorBalancesRootProof.Proof.ToByteSlice(),
+			BalanceContainerRoot: proof.ValidatorBalancesRoot,
+			Proof:                proof.Proof.ToByteSlice(),
 		},
-		CastBalanceProofs(proof.BalanceProofs),
+		CastBalanceProofs(balanceProofs),
 	)
 	if err != nil {
 		return nil, err

--- a/cli/core/checkpoint.go
+++ b/cli/core/checkpoint.go
@@ -20,7 +20,7 @@ import (
 
 const PROOFS_PER_BATCH = 60 // about 60 proofs fit per transaction.
 
-func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.VerifyCheckpointProofsCallParams, eth *ethclient.Client, batchSize int, noPrompt bool) ([]*types.Transaction, error) {
+func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.VerifyCheckpointProofsCallParams, eth *ethclient.Client, batchSize uint64, noPrompt bool) ([]*types.Transaction, error) {
 	allProofChunks := chunk(proof.BalanceProofs, PROOFS_PER_BATCH)
 
 	transactions := []*types.Transaction{}
@@ -47,7 +47,7 @@ func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, c
 	return transactions, nil
 }
 
-func SubmitCheckpointProofBatch(owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.VerifyCheckpointProofsCallParams, balanceProofs []*eigenpodproofs.BalanceProof, eth *ethclient.Client, batchSize int) (*types.Transaction, error) {
+func SubmitCheckpointProofBatch(owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.VerifyCheckpointProofsCallParams, balanceProofs []*eigenpodproofs.BalanceProof, eth *ethclient.Client, batchSize uint64) (*types.Transaction, error) {
 	ownerAccount, err := PrepareAccount(&owner, chainId)
 	if err != nil {
 		return nil, err

--- a/cli/core/checkpoint.go
+++ b/cli/core/checkpoint.go
@@ -22,9 +22,6 @@ func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, c
 	allProofChunks := chunk(proof.BalanceProofs, batchSize)
 
 	transactions := []*types.Transaction{}
-	if !noPrompt {
-		PanicIfNoConsent(SubmitCheckpointProofConsent(len(allProofChunks)))
-	}
 
 	color.Green("calling EigenPod.VerifyCheckpointProofs() (using %d txn(s), max(%d) proofs per txn)", len(allProofChunks), batchSize)
 

--- a/cli/core/checkpoint.go
+++ b/cli/core/checkpoint.go
@@ -18,10 +18,8 @@ import (
 	"github.com/fatih/color"
 )
 
-const PROOFS_PER_BATCH = 60 // about 60 proofs fit per transaction.
-
 func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.VerifyCheckpointProofsCallParams, eth *ethclient.Client, batchSize uint64, noPrompt bool) ([]*types.Transaction, error) {
-	allProofChunks := chunk(proof.BalanceProofs, PROOFS_PER_BATCH)
+	allProofChunks := chunk(proof.BalanceProofs, batchSize)
 
 	transactions := []*types.Transaction{}
 	if !noPrompt {
@@ -32,7 +30,7 @@ func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, c
 
 	for i := 0; i < len(allProofChunks); i++ {
 		balanceProofs := allProofChunks[i]
-		txn, err := SubmitCheckpointProofBatch(owner, eigenpodAddress, chainId, proof, balanceProofs, eth, batchSize)
+		txn, err := SubmitCheckpointProofBatch(owner, eigenpodAddress, chainId, proof, balanceProofs, eth)
 		if err != nil {
 			// failed to submit batch.
 			return transactions, err
@@ -47,7 +45,7 @@ func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, c
 	return transactions, nil
 }
 
-func SubmitCheckpointProofBatch(owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.VerifyCheckpointProofsCallParams, balanceProofs []*eigenpodproofs.BalanceProof, eth *ethclient.Client, batchSize uint64) (*types.Transaction, error) {
+func SubmitCheckpointProofBatch(owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.VerifyCheckpointProofsCallParams, balanceProofs []*eigenpodproofs.BalanceProof, eth *ethclient.Client) (*types.Transaction, error) {
 	ownerAccount, err := PrepareAccount(&owner, chainId)
 	if err != nil {
 		return nil, err

--- a/cli/core/checkpoint.go
+++ b/cli/core/checkpoint.go
@@ -23,7 +23,7 @@ func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, c
 
 	transactions := []*types.Transaction{}
 	if !noPrompt {
-		PanicIfNoConsent(fmt.Sprintf("This will call EigenPod.VerifyCheckpointProofs() %d time(s), to complete your checkpoint.", len(allProofChunks)))
+		PanicIfNoConsent(SubmitCheckpointProofConsent(len(allProofChunks)))
 	}
 
 	color.Green("calling EigenPod.VerifyCheckpointProofs() (using %d txn(s), max(%d) proofs per txn)", len(allProofChunks), batchSize)

--- a/cli/core/checkpoint.go
+++ b/cli/core/checkpoint.go
@@ -20,10 +20,13 @@ import (
 
 const PROOFS_PER_BATCH = 60 // about 60 proofs fit per transaction.
 
-func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.VerifyCheckpointProofsCallParams, eth *ethclient.Client, batchSize int) ([]*types.Transaction, error) {
+func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.VerifyCheckpointProofsCallParams, eth *ethclient.Client, batchSize int, noPrompt bool) ([]*types.Transaction, error) {
 	allProofChunks := chunk(proof.BalanceProofs, PROOFS_PER_BATCH)
 
 	transactions := []*types.Transaction{}
+	if !noPrompt {
+		PanicIfNoConsent(fmt.Sprintf("This will call EigenPod.VerifyCheckpointProofs() %d time(s), to complete your checkpoint.", len(allProofChunks)))
+	}
 
 	color.Green("calling EigenPod.VerifyCheckpointProofs() (using %d txn(s), max(%d) proofs per txn)", len(allProofChunks), batchSize)
 

--- a/cli/core/messages.go
+++ b/cli/core/messages.go
@@ -11,10 +11,10 @@ func plural(word string, amount int) string {
 	return word
 }
 
-func SubmitCheckpointProofConsent(numTransactions int) string {
-	return fmt.Sprintf(`This will start a new checkpoint on your eigenpod.
+func StartCheckpointProofConsent() string {
+	return `This will start a new checkpoint on your eigenpod.
 
-	Once started, you MUST complete this checkpoint. This may entail submitting %d or more transactions.
+	Once started, you MUST complete this checkpoint. To see the full impact and transaction requirement of the checkpoint, rerun with 'status'.
 
 	Note that if you lose the generated proofs, you'll need to recompute them. Beacon state is large, and many nodes do not retain
 	long amounts of state. You can always recompute the proofs against a full archival beacon node, but you may face issues if 
@@ -22,11 +22,7 @@ func SubmitCheckpointProofConsent(numTransactions int) string {
 
 	You should be comfortable with submitting all of these before beginning.
 	
-	PLAN: This will call EigenPod.VerifyCheckpointProofs() %d %s to complete your checkpoint.`,
-		numTransactions,
-		numTransactions,
-		plural("time", numTransactions),
-	)
+	PLAN: This will call EigenPod.VerifyCheckpointProofs(), with batches of proofs, to complete your checkpoint. For full details, run status.`
 }
 
 func SubmitCredentialsProofConsent(numTransactions int) string {

--- a/cli/core/messages.go
+++ b/cli/core/messages.go
@@ -1,0 +1,37 @@
+package core
+
+import (
+	"fmt"
+)
+
+func plural(word string, amount int) string {
+	if amount > 1 {
+		return word + "s"
+	}
+	return word
+}
+
+func SubmitCheckpointProofConsent(numTransactions int) string {
+	return fmt.Sprintf(`This will start a new checkpoint on your eigenpod.
+
+	Once started, you MUST complete this checkpoint. This may entail submitting %d or more transactions.
+	You should be comfortable with submitting all of these before beginning.
+	
+	This will call EigenPod.VerifyCheckpointProofs() %d %s, to complete your checkpoint.`,
+		numTransactions,
+		numTransactions,
+		plural("time", numTransactions),
+	)
+}
+
+func SubmitCredentialsProofConsent(numTransactions int) string {
+	return fmt.Sprintf(`This will verify the withdrawal credentials of your validator, "restaking" your validator for the first time.
+	Once submitted, future checkpoint proofs will include a balance proof against this validator. 
+
+	This will call EigenPod.VerifyWithdrawalCredentials(), using %d %s, to link your %s to your eigenpod.
+	`,
+		numTransactions,
+		plural("time", numTransactions),
+		plural("validator", numTransactions),
+	)
+}

--- a/cli/core/messages.go
+++ b/cli/core/messages.go
@@ -15,9 +15,14 @@ func SubmitCheckpointProofConsent(numTransactions int) string {
 	return fmt.Sprintf(`This will start a new checkpoint on your eigenpod.
 
 	Once started, you MUST complete this checkpoint. This may entail submitting %d or more transactions.
+
+	Note that if you lose the generated proofs, you'll need to recompute them. Beacon state is large, and many nodes do not retain
+	long amounts of state. You can always recompute the proofs against a full archival beacon node, but you may face issues if 
+	your beacon node is not archival.
+
 	You should be comfortable with submitting all of these before beginning.
 	
-	This will call EigenPod.VerifyCheckpointProofs() %d %s, to complete your checkpoint.`,
+	PLAN: This will call EigenPod.VerifyCheckpointProofs() %d %s to complete your checkpoint.`,
 		numTransactions,
 		numTransactions,
 		plural("time", numTransactions),
@@ -28,7 +33,7 @@ func SubmitCredentialsProofConsent(numTransactions int) string {
 	return fmt.Sprintf(`This will verify the withdrawal credentials of your validator, "restaking" your validator for the first time.
 	Once submitted, future checkpoint proofs will include a balance proof against this validator. 
 
-	This will call EigenPod.VerifyWithdrawalCredentials(), using %d %s, to link your %s to your eigenpod.
+	PLAN: This will call EigenPod.VerifyWithdrawalCredentials() %d %s to link your %s to your eigenpod.
 	`,
 		numTransactions,
 		plural("time", numTransactions),

--- a/cli/core/status.go
+++ b/cli/core/status.go
@@ -30,6 +30,8 @@ type EigenpodStatus struct {
 
 	ActiveCheckpoint *Checkpoint
 
+	NumberValidatorsToCheckpoint int
+
 	CurrentTotalSharesETH *big.Float
 	Status                int
 
@@ -73,6 +75,9 @@ func GetStatus(ctx context.Context, eigenpodAddress string, eth *ethclient.Clien
 
 	allValidators := FindAllValidatorsForEigenpod(eigenpodAddress, state)
 	activeValidators := SelectActiveValidators(eth, eigenpodAddress, allValidators)
+
+	checkpointableValidators := SelectCheckpointableValidators(eth, eigenpodAddress, allValidators, timestamp)
+
 	sumRegularBalancesGwei := sumBeaconChainRegularBalancesGwei(activeValidators, state)
 
 	for i := 0; i < len(allValidators); i++ {
@@ -147,5 +152,6 @@ func GetStatus(ctx context.Context, eigenpodAddress string, eth *ethclient.Clien
 		CurrentTotalSharesETH:          currentOwnerSharesETH,
 		TotalSharesAfterCheckpointGwei: pendingSharesGwei,
 		TotalSharesAfterCheckpointETH:  pendingEth,
+		NumberValidatorsToCheckpoint:   len(checkpointableValidators),
 	}
 }

--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -62,9 +62,48 @@ func PanicOnError(message string, err error) {
 	}
 }
 
+func chunk[T any](arr []T, chunkSize int) [][]T {
+	// Validate the chunkSize to ensure it's positive
+	if chunkSize <= 0 {
+		panic("chunkSize must be greater than 0")
+	}
+
+	// Create a slice to hold the chunks
+	var chunks [][]T
+
+	// Loop through the input slice and create chunks
+	for i := 0; i < len(arr); i += chunkSize {
+		end := i + chunkSize
+		if end > len(arr) {
+			end = len(arr)
+		}
+		chunks = append(chunks, arr[i:end])
+	}
+
+	return chunks
+}
+
 type ValidatorWithIndex = struct {
 	Validator *phase0.Validator
 	Index     uint64
+}
+
+func withDryRun(opts *bind.TransactOpts) *bind.TransactOpts {
+	// golang doesn't have a spread operator for structs smh
+	return &bind.TransactOpts{
+		From:   opts.From,
+		Nonce:  opts.Nonce,
+		Signer: opts.Signer,
+
+		Value:     opts.Value,
+		GasPrice:  opts.GasPrice,
+		GasFeeCap: opts.GasFeeCap,
+		GasTipCap: opts.GasTipCap,
+		GasLimit:  0, // Gas limit to set for the transaction execution (0 = estimate)
+
+		Context: opts.Context, // Network context to support cancellation and timeouts (nil = no timeout)
+		NoSend:  true,         // Do all transact steps but do not send the transaction
+	}
 }
 
 type Owner = struct {

--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -62,7 +62,7 @@ func PanicOnError(message string, err error) {
 	}
 }
 
-func chunk[T any](arr []T, chunkSize int) [][]T {
+func chunk[T any](arr []T, chunkSize uint64) [][]T {
 	// Validate the chunkSize to ensure it's positive
 	if chunkSize <= 0 {
 		panic("chunkSize must be greater than 0")
@@ -72,10 +72,11 @@ func chunk[T any](arr []T, chunkSize int) [][]T {
 	var chunks [][]T
 
 	// Loop through the input slice and create chunks
-	for i := 0; i < len(arr); i += chunkSize {
-		end := i + chunkSize
-		if end > len(arr) {
-			end = len(arr)
+	arrLen := uint64(len(arr))
+	for i := uint64(0); i < arrLen; i += chunkSize {
+		end := uint64(i + chunkSize)
+		if end > arrLen {
+			end = arrLen
 		}
 		chunks = append(chunks, arr[i:end])
 	}

--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -241,6 +241,18 @@ func CastBalanceProofs(proofs []*eigenpodproofs.BalanceProof) []onchain.BeaconCh
 	return out
 }
 
+func PanicIfNoConsent(prompt string) {
+	color.New(color.Bold).Printf("%s - Do you want to proceed? (y/n): ", prompt)
+	var reply string
+
+	fmt.Scanln(&reply)
+	if reply == "y" {
+		return
+	} else {
+		Panic("abort.")
+	}
+}
+
 func PrepareAccount(owner *string, chainID *big.Int) (*Owner, error) {
 	if owner == nil {
 		return nil, fmt.Errorf("no owner")

--- a/cli/core/validator.go
+++ b/cli/core/validator.go
@@ -53,7 +53,7 @@ func SubmitValidatorProof(ctx context.Context, owner, eigenpodAddress string, ch
 		var curValidatorFields [][][32]byte = CastValidatorFields(validatorFieldsChunks[i])
 
 		fmt.Printf("Submitted chunk %d/%d -- waiting for transaction...: ", i+1, numChunks)
-		txn, err := SubmitValidatorProofChunk(ctx, ownerAccount, eigenPod, chainId, eth, curValidatorIndices, curValidatorFields, proofs, validatorFieldsProofs, oracleBeaconTimesetamp)
+		txn, err := SubmitValidatorProofChunk(ctx, ownerAccount, eigenPod, chainId, eth, curValidatorIndices, curValidatorFields, proofs.StateRootProof, validatorFieldsProofs, oracleBeaconTimesetamp)
 		if err != nil {
 			return transactions, err
 		}
@@ -64,14 +64,14 @@ func SubmitValidatorProof(ctx context.Context, owner, eigenpodAddress string, ch
 	return transactions, err
 }
 
-func SubmitValidatorProofChunk(ctx context.Context, ownerAccount *Owner, eigenPod *onchain.EigenPod, chainId *big.Int, eth *ethclient.Client, indices []*big.Int, validatorFields [][][32]byte, proofs *eigenpodproofs.VerifyValidatorFieldsCallParams, validatorFieldsProofs [][]byte, oracleBeaconTimesetamp uint64) (*types.Transaction, error) {
+func SubmitValidatorProofChunk(ctx context.Context, ownerAccount *Owner, eigenPod *onchain.EigenPod, chainId *big.Int, eth *ethclient.Client, indices []*big.Int, validatorFields [][][32]byte, stateRootProofs *eigenpodproofs.StateRootProof, validatorFieldsProofs [][]byte, oracleBeaconTimesetamp uint64) (*types.Transaction, error) {
 	color.Green("submitting onchain...")
 	txn, err := eigenPod.VerifyWithdrawalCredentials(
 		ownerAccount.TransactionOptions,
 		oracleBeaconTimesetamp,
 		onchain.BeaconChainProofsStateRootProof{
-			Proof:           proofs.StateRootProof.Proof.ToByteSlice(),
-			BeaconStateRoot: proofs.StateRootProof.BeaconStateRoot,
+			Proof:           stateRootProofs.Proof.ToByteSlice(),
+			BeaconStateRoot: stateRootProofs.BeaconStateRoot,
 		},
 		indices,
 		validatorFieldsProofs,

--- a/cli/core/validator.go
+++ b/cli/core/validator.go
@@ -36,11 +36,6 @@ func SubmitValidatorProof(ctx context.Context, owner, eigenpodAddress string, ch
 
 	color.Green("calling EigenPod.VerifyWithdrawalCredentials() (using %d txn(s), max(%d) proofs per txn)", len(indices), batchSize)
 
-	latestBlock, err := eth.BlockByNumber(ctx, nil)
-	if err != nil {
-		return []*types.Transaction{}, err
-	}
-
 	transactions := []*types.Transaction{}
 	numChunks := len(validatorIndicesChunks)
 
@@ -58,7 +53,7 @@ func SubmitValidatorProof(ctx context.Context, owner, eigenpodAddress string, ch
 		var curValidatorFields [][][32]byte = CastValidatorFields(validatorFieldsChunks[i])
 
 		fmt.Printf("Submitted chunk %d/%d -- waiting for transaction...: ", i+1, numChunks)
-		txn, err := SubmitValidatorProofChunk(ctx, ownerAccount, eigenPod, chainId, eth, curValidatorIndices, curValidatorFields, proofs, validatorFieldsProofs, latestBlock.Time())
+		txn, err := SubmitValidatorProofChunk(ctx, ownerAccount, eigenPod, chainId, eth, curValidatorIndices, curValidatorFields, proofs, validatorFieldsProofs, oracleBeaconTimesetamp)
 		if err != nil {
 			return transactions, err
 		}

--- a/cli/core/validator.go
+++ b/cli/core/validator.go
@@ -14,7 +14,7 @@ import (
 	"github.com/fatih/color"
 )
 
-func SubmitValidatorProof(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, eth *ethclient.Client, batchSize uint64, proofs *eigenpodproofs.VerifyValidatorFieldsCallParams, noPrompt bool) ([]*types.Transaction, error) {
+func SubmitValidatorProof(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, eth *ethclient.Client, batchSize uint64, proofs *eigenpodproofs.VerifyValidatorFieldsCallParams, oracleBeaconTimesetamp uint64, noPrompt bool) ([]*types.Transaction, error) {
 	ownerAccount, err := PrepareAccount(&owner, chainId)
 	if err != nil {
 		return nil, err
@@ -86,28 +86,38 @@ func SubmitValidatorProofChunk(ctx context.Context, ownerAccount *Owner, eigenPo
 	return txn, err
 }
 
-func GenerateValidatorProof(ctx context.Context, eigenpodAddress string, eth *ethclient.Client, chainId *big.Int, beaconClient BeaconClient) *eigenpodproofs.VerifyValidatorFieldsCallParams {
+func GenerateValidatorProof(ctx context.Context, eigenpodAddress string, eth *ethclient.Client, chainId *big.Int, beaconClient BeaconClient) (*eigenpodproofs.VerifyValidatorFieldsCallParams, uint64, error) {
 	latestBlock, err := eth.BlockByNumber(ctx, nil)
-	PanicOnError("failed to load latest block", err)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to load latest block: %w", err)
+	}
 
 	eigenPod, err := onchain.NewEigenPod(common.HexToAddress(eigenpodAddress), eth)
-	PanicOnError("failed to reach eigenpod", err)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to reach eigenpod: %w", err)
+	}
 
 	expectedBlockRoot, err := eigenPod.GetParentBlockRoot(nil, latestBlock.Time())
-	PanicOnError("failed to load parent block root", err)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to load parent block root: %w", err)
+	}
 
 	header, err := beaconClient.GetBeaconHeader(ctx, "0x"+common.Bytes2Hex(expectedBlockRoot[:]))
-	PanicOnError("failed to fetch beacon header.", err)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to fetch beacon header: %w", err)
+	}
 
 	beaconState, err := beaconClient.GetBeaconState(ctx, strconv.FormatUint(uint64(header.Header.Message.Slot), 10))
-	PanicOnError("failed to fetch beacon state.", err)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to fetch beacon state: %w", err)
+	}
 
 	allValidators := FindAllValidatorsForEigenpod(eigenpodAddress, beaconState)
 	awaitingCredentialValidators := SelectAwaitingCredentialValidators(eth, eigenpodAddress, allValidators)
 
 	if len(awaitingCredentialValidators) == 0 {
 		color.Red("You have no inactive validators to verify. Everything up-to-date.")
-		return nil
+		return nil, 0, nil
 	} else {
 		color.Blue("Verifying %d inactive validators", len(awaitingCredentialValidators))
 	}
@@ -118,11 +128,15 @@ func GenerateValidatorProof(ctx context.Context, eigenpodAddress string, eth *et
 	}
 
 	proofs, err := eigenpodproofs.NewEigenPodProofs(chainId.Uint64(), 300 /* oracleStateCacheExpirySeconds - 5min */)
-	PanicOnError("failled to initialize prover", err)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to initialize provider: %w", err)
+	}
 
 	// validator proof
 	validatorProofs, err := proofs.ProveValidatorContainers(header.Header.Message, beaconState, validatorIndices)
-	PanicOnError("failed to prove validators.", err)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to prove validators: %w", err)
+	}
 
-	return validatorProofs
+	return validatorProofs, latestBlock.Time(), nil
 }

--- a/cli/core/validator.go
+++ b/cli/core/validator.go
@@ -14,7 +14,7 @@ import (
 	"github.com/fatih/color"
 )
 
-func SubmitValidatorProof(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, eth *ethclient.Client, batchSize int, proofs *eigenpodproofs.VerifyValidatorFieldsCallParams, noPrompt bool) ([]*types.Transaction, error) {
+func SubmitValidatorProof(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, eth *ethclient.Client, batchSize uint64, proofs *eigenpodproofs.VerifyValidatorFieldsCallParams, noPrompt bool) ([]*types.Transaction, error) {
 
 	ownerAccount, err := PrepareAccount(&owner, chainId)
 	if err != nil {

--- a/cli/core/validator.go
+++ b/cli/core/validator.go
@@ -31,7 +31,7 @@ func SubmitValidatorProof(ctx context.Context, owner, eigenpodAddress string, ch
 	validatorProofsChunks := chunk(proofs.ValidatorFieldsProofs, batchSize)
 	validatorFieldsChunks := chunk(proofs.ValidatorFields, batchSize)
 	if !noPrompt {
-		PanicIfNoConsent(fmt.Sprintf("This will call EigenPod.VerifyWithdrawalCredentials() %d times, to link your validator to your eigenpod.", len(validatorIndicesChunks)))
+		PanicIfNoConsent(SubmitCredentialsProofConsent(len(validatorFieldsChunks)))
 	}
 
 	color.Green("calling EigenPod.VerifyWithdrawalCredentials() (using %d txn(s), max(%d) proofs per txn)", len(indices), batchSize)

--- a/cli/core/validator.go
+++ b/cli/core/validator.go
@@ -15,7 +15,6 @@ import (
 )
 
 func SubmitValidatorProof(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, eth *ethclient.Client, batchSize uint64, proofs *eigenpodproofs.VerifyValidatorFieldsCallParams, noPrompt bool) ([]*types.Transaction, error) {
-
 	ownerAccount, err := PrepareAccount(&owner, chainId)
 	if err != nil {
 		return nil, err
@@ -58,6 +57,7 @@ func SubmitValidatorProof(ctx context.Context, owner, eigenpodAddress string, ch
 		}
 		var curValidatorFields [][][32]byte = CastValidatorFields(validatorFieldsChunks[i])
 
+		fmt.Printf("Submitted chunk %d/%d -- waiting for transaction...: ", i+1, numChunks)
 		txn, err := SubmitValidatorProofChunk(ctx, ownerAccount, eigenPod, chainId, eth, curValidatorIndices, curValidatorFields, proofs, validatorFieldsProofs, latestBlock.Time())
 		if err != nil {
 			return transactions, err

--- a/cli/core/validator.go
+++ b/cli/core/validator.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"strconv"
 
@@ -13,7 +14,7 @@ import (
 	"github.com/fatih/color"
 )
 
-func SubmitValidatorProof(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, eth *ethclient.Client, batchSize int, proofs *eigenpodproofs.VerifyValidatorFieldsCallParams) ([]*types.Transaction, error) {
+func SubmitValidatorProof(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, eth *ethclient.Client, batchSize int, proofs *eigenpodproofs.VerifyValidatorFieldsCallParams, noPrompt bool) ([]*types.Transaction, error) {
 
 	ownerAccount, err := PrepareAccount(&owner, chainId)
 	if err != nil {
@@ -30,6 +31,9 @@ func SubmitValidatorProof(ctx context.Context, owner, eigenpodAddress string, ch
 	validatorIndicesChunks := chunk(indices, batchSize)
 	validatorProofsChunks := chunk(proofs.ValidatorFieldsProofs, batchSize)
 	validatorFieldsChunks := chunk(proofs.ValidatorFields, batchSize)
+	if !noPrompt {
+		PanicIfNoConsent(fmt.Sprintf("This will call EigenPod.VerifyWithdrawalCredentials() %d times, to link your validator to your eigenpod.", len(validatorIndicesChunks)))
+	}
 
 	color.Green("calling EigenPod.VerifyWithdrawalCredentials() (using %d txn(s), max(%d) proofs per txn)", len(indices), batchSize)
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -20,8 +20,8 @@ func shortenHex(publicKey string) string {
 }
 
 // shared flag --batch
-func BatchBySize(destination *int, defaultValue int) *cli.IntFlag {
-	return &cli.IntFlag{
+func BatchBySize(destination *uint64, defaultValue uint64) *cli.Uint64Flag {
+	return &cli.Uint64Flag{
 		Name:        "batch",
 		Value:       defaultValue,
 		Usage:       "Submit proofs in groups of size `--batch <batchSize>`, to avoid gas limit.",
@@ -32,7 +32,7 @@ func BatchBySize(destination *int, defaultValue int) *cli.IntFlag {
 
 func main() {
 	var eigenpodAddress, beacon, node, owner, output string
-	var batchSize int
+	var batchSize uint64
 	var checkpointProofPath string
 	var forceCheckpoint, disableColor, verbose bool
 	var noPrompt bool

--- a/cli/main.go
+++ b/cli/main.go
@@ -239,13 +239,14 @@ func main() {
 					}
 
 					eth, beaconClient, chainId := core.GetClients(ctx, node, beacon)
-					validatorProofs := core.GenerateValidatorProof(ctx, eigenpodAddress, eth, chainId, beaconClient)
-					if validatorProofs == nil {
-						return nil
+					validatorProofs, oracleBeaconTimestamp, err := core.GenerateValidatorProof(ctx, eigenpodAddress, eth, chainId, beaconClient)
+					if err != nil || validatorProofs == nil {
+						core.PanicOnError("Failed to generate validator proof", err)
+						core.Panic("no inactive validators")
 					}
 
 					if owner != nil {
-						txns, err := core.SubmitValidatorProof(ctx, *owner, eigenpodAddress, chainId, eth, batchSize, validatorProofs, noPrompt)
+						txns, err := core.SubmitValidatorProof(ctx, *owner, eigenpodAddress, chainId, eth, batchSize, validatorProofs, oracleBeaconTimestamp, noPrompt)
 						core.PanicOnError("failed to invoke verifyWithdrawalCredentials", err)
 						for i, txn := range txns {
 							color.Green("transaction(%d): %s", i, txn.Hash().Hex())


### PR DESCRIPTION
**Interface**

- `--batch <batchSize>` modifies the default batch size used. @wadealexc determined 80 for checkpoint, 60 for credentials as the values to use. 
- technically all the code is batched now (but < BATCH_SIZE just produces 1 batch).

**Demo** 
on holesky, submitting 1 batch:
![image](https://github.com/Layr-Labs/eigenpod-proofs-generation/assets/2030176/c36710e4-99b3-4f03-84fb-b03e929cab4f)
