### PR TITLE
Support precaching of `eigenpodproofs` intermediates

### DIFF
--- a/eigen_pod_proofs.go
+++ b/eigen_pod_proofs.go
@@ -49,10 +49,27 @@ func NewEigenPodProofs(chainID uint64, oracleStateCacheExpirySeconds int) (*Eige
 	}, nil
 }
 
-func (epp *EigenPodProofs) PrecomputeCache(state *spec.VersionedBeaconState) {
+func (epp *EigenPodProofs) PrecomputeCache(state *spec.VersionedBeaconState) error {
+	slot, err := state.Slot()
+	if err != nil {
+		return err
+	}
+	validators, err := state.Validators()
+	if err != nil {
+		return err
+	}
+
+	balances, err := state.ValidatorBalances()
+	if err != nil {
+		return err
+	}
+
 	epp.ComputeBeaconStateRoot(state.Deneb)
 	epp.ComputeBeaconStateTopLevelRoots(state)
 	epp.ComputeVersionedBeaconStateTopLevelRoots(state)
+	epp.ComputeValidatorTree(slot, validators)
+	epp.ComputeValidatorBalancesTree(slot, balances)
+	return nil
 }
 
 func (epp *EigenPodProofs) ComputeBeaconStateRoot(beaconState *deneb.BeaconState) (phase0.Root, error) {

--- a/eigen_pod_proofs.go
+++ b/eigen_pod_proofs.go
@@ -49,6 +49,12 @@ func NewEigenPodProofs(chainID uint64, oracleStateCacheExpirySeconds int) (*Eige
 	}, nil
 }
 
+func (epp *EigenPodProofs) PrecomputeCache(state *spec.VersionedBeaconState) {
+	epp.ComputeBeaconStateRoot(state.Deneb)
+	epp.ComputeBeaconStateTopLevelRoots(state)
+	epp.ComputeVersionedBeaconStateTopLevelRoots(state)
+}
+
 func (epp *EigenPodProofs) ComputeBeaconStateRoot(beaconState *deneb.BeaconState) (phase0.Root, error) {
 	beaconStateRoot, err := epp.loadOrComputeBeaconStateRoot(
 		beaconState.Slot,


### PR DESCRIPTION
- Use a few of the `Compute()` functions, grouped up, to allow the eigenpodproofs object to pre compute some of the data needed for live proving.
- Expose the `proofs` argument on our proof computation function so that the backend can optimistically cache using this structure.