### PR TITLE
Capitalizations in the logs

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -45,7 +45,7 @@ func main() {
 	ctx := context.Background()
 
 	app := &cli.App{
-		Name:                   "Eigenlayer Proofs CLi",
+		Name:                   "EigenLayer Proofs CLI",
 		HelpName:               "eigenproofs",
 		Usage:                  "Generates proofs to (1) checkpoint your validators, or (2) verify the withdrawal credentials of an inactive validator.",
 		EnableBashCompletion:   true,

--- a/cli/main.go
+++ b/cli/main.go
@@ -155,7 +155,7 @@ func main() {
 					&cli.StringFlag{
 						Name:        "proof",
 						Value:       "",
-						Usage:       "the path to a previous proof generated from this step (via `-o proof.json`). If provided, this proof will submitted to network via the `--owner` flag.",
+						Usage:       "The path to a previous proof generated from this step (via `-o proof.json`). If provided, this proof will submitted to network via the `--owner` flag.",
 						Destination: &checkpointProofPath,
 					},
 					&cli.StringFlag{


### PR DESCRIPTION
A commit that fixes (lack of) capitalization in some of the CLI logs