### PR TITLE
fix SelectCheckpointableValidators w/ no checkpoint

### DIFF
--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -380,7 +380,7 @@ func SelectCheckpointableValidators(
 		validator := validators[i]
 		validatorInfo := validatorInfos[i]
 
-		notCheckpointed := validatorInfo.LastCheckpointedAt != lastCheckpoint
+		notCheckpointed := (validatorInfo.LastCheckpointedAt != lastCheckpoint) || (validatorInfo.LastCheckpointedAt == 0)
 		isActive := validatorInfo.Status == ValidatorStatusActive
 
 		if notCheckpointed && isActive {

--- a/cli/main.go
+++ b/cli/main.go
@@ -276,8 +276,8 @@ func main() {
 
 							ital.Printf("\t%f new shares issued (%f ==> %f)\n", deltaETH, status.CurrentTotalSharesETH, status.TotalSharesAfterCheckpointETH)
 
-							bold.Printf("This will require:\n\t")
-							ital.Printf("- 1x startCheckpoint() transaction, and \n\t- %dx EigenPod.verifyCheckpointProofs() transaction(s)\n\n", int(math.Ceil(float64(status.NumberValidatorsToCheckpoint)/float64(80))))
+							bold.Printf("Batching %d proofs per txn, this will require:\n\t", DEFAULT_BATCH_CHECKPOINT)
+							ital.Printf("- 1x startCheckpoint() transaction, and \n\t- %dx EigenPod.verifyCheckpointProofs() transaction(s)\n\n", int(math.Ceil(float64(status.NumberValidatorsToCheckpoint)/float64(DEFAULT_BATCH_CHECKPOINT))))
 						}
 					}
 					return nil


### PR DESCRIPTION
…s been created before
* When no checkpoint has been created on a pod before, the checkpoint timestamp is 0, and the LastCheckpointedAt for any verified validators is also 0. This fixes SelectCheckpointableValidators  to account for this edge case.