### PR TITLE
feat: display whether checkpoint must be forced in status cmd

### DIFF
--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -128,6 +128,10 @@ func StartCheckpoint(ctx context.Context, eigenpodAddress string, ownerPrivateKe
 
 	txn, err := eigenPod.StartCheckpoint(ownerAccount.TransactionOptions, revertIfNoBalance)
 	if err != nil {
+		if !forceCheckpoint {
+			return 0, fmt.Errorf("failed to start checkpoint (try running again with `--force`): %w", err)
+		}
+
 		return 0, fmt.Errorf("failed to start checkpoint: %w", err)
 	}
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -276,6 +276,10 @@ func main() {
 
 							ital.Printf("\t%f new shares issued (%f ==> %f)\n", deltaETH, status.CurrentTotalSharesETH, status.TotalSharesAfterCheckpointETH)
 
+							if status.MustForceCheckpoint {
+								ylw.Printf("\tNote: pod does not have checkpointable native ETH. To checkpoint anyway, run `checkpoint` with the `--force` flag.\n")
+							}
+
 							bold.Printf("Batching %d proofs per txn, this will require:\n\t", DEFAULT_BATCH_CHECKPOINT)
 							ital.Printf("- 1x startCheckpoint() transaction, and \n\t- %dx EigenPod.verifyCheckpointProofs() transaction(s)\n\n", int(math.Ceil(float64(status.NumberValidatorsToCheckpoint)/float64(DEFAULT_BATCH_CHECKPOINT))))
 						}


### PR DESCRIPTION
Problem: especially when testing, it's helpful to create a bunch of checkpoints in a short period of time. This means we're often running the `checkpoint` command when there's no native ETH to be checkpointed, as beacon chain rewards haven't hit the pod since the last checkpoint performed.

This change adds:
* a more specific error message prompting the user to run again with `--force` if their `checkpoint` failed
* output to the `status` command that detects if `--force` will be needed to successfully start the checkpoint