### PR TITLE
Configurable Tracing

### DIFF
--- a/cli/core/tracing.go
+++ b/cli/core/tracing.go
@@ -1,0 +1,29 @@
+package core
+
+import (
+	"context"
+)
+
+type TracerCallbacks struct {
+	OnStartSection func(name string, metadata map[string]string)
+	OnEndSection   func()
+}
+type TEigenKey string
+
+const EIGEN_KEY TEigenKey = "com.eigen.tracer"
+
+func ContextWithTracing(ctx context.Context, callbacks *TracerCallbacks) context.Context {
+	return context.WithValue(ctx, EIGEN_KEY, callbacks)
+}
+
+func GetContextTracingCallbacks(ctx context.Context) *TracerCallbacks {
+	tracing := ctx.Value(EIGEN_KEY).(*TracerCallbacks)
+	if tracing == nil {
+		return &TracerCallbacks{
+			OnStartSection: func(name string, meta map[string]string) {},
+			OnEndSection:   func() {},
+		}
+	}
+
+	return tracing
+}


### PR DESCRIPTION
- Add an abstraction for tracing that we can use to performance-analyse the proof generation on the backend (which uses cli/core).
- In the CLI this will continue to no-op.