### PR TITLE
Support generating a credential proof against a specific validator 

### DIFF
--- a/cli/core/validator.go
+++ b/cli/core/validator.go
@@ -82,6 +82,10 @@ func SubmitValidatorProofChunk(ctx context.Context, ownerAccount *Owner, eigenPo
 	return txn, err
 }
 
+/**
+ * Generates a .ProveValidatorContainers() proof for all eligible validators on the pod. If `validatorIndex` is set, it will only generate  a proof
+ * against that validator, regardless of the validator's state.
+ */
 func GenerateValidatorProof(ctx context.Context, eigenpodAddress string, eth *ethclient.Client, chainId *big.Int, beaconClient BeaconClient, validatorIndex *big.Int) (*eigenpodproofs.VerifyValidatorFieldsCallParams, uint64, error) {
 	latestBlock, err := eth.BlockByNumber(ctx, nil)
 	if err != nil {

--- a/cli/core/validator.go
+++ b/cli/core/validator.go
@@ -134,7 +134,7 @@ func GenerateValidatorProofAtState(proofs *eigenpodproofs.EigenPodProofs, eigenp
 			}
 		}
 		if len(awaitingCredentialValidators) == 0 {
-			return nil, fmt.Errorf("no such validator at index %d", forSpecificValidator.Uint64())
+			return nil, fmt.Errorf("validator at index %d does not exist or does not have withdrawal credentials set to pod %s", forSpecificValidator.Uint64(), eigenpodAddress)
 		}
 	} else {
 		// default behavior -- load any validators that are inactive / need a credential proof

--- a/cli/main.go
+++ b/cli/main.go
@@ -439,7 +439,7 @@ func main() {
 					SENDER_PK_FLAG,
 					BatchBySize(&batchSize, DEFAULT_BATCH_CREDENTIALS),
 					&cli.Uint64Flag{
-						Name:        "validator",
+						Name:        "validatorIndex",
 						Usage:       "The `index` of a specific validator to prove (e.g a slashed validator for `verifyStaleBalance()`).",
 						Destination: &specificValidator,
 					},

--- a/cli/main.go
+++ b/cli/main.go
@@ -28,7 +28,7 @@ func BatchBySize(destination *uint64, defaultValue uint64) *cli.Uint64Flag {
 	return &cli.Uint64Flag{
 		Name:        "batch",
 		Value:       defaultValue,
-		Usage:       "Submit proofs in groups of size `--batch <batchSize>`, to avoid gas limit.",
+		Usage:       "Submit proofs in groups of size `batchSize`, to avoid gas limit.",
 		Required:    false,
 		Destination: destination,
 	}
@@ -440,7 +440,7 @@ func main() {
 					BatchBySize(&batchSize, DEFAULT_BATCH_CREDENTIALS),
 					&cli.Uint64Flag{
 						Name:        "validator",
-						Usage:       "The index of a specific validator to prove (e.g a slashed validator for `verifyStaleBalance()`).",
+						Usage:       "The `index` of a specific validator to prove (e.g a slashed validator for `verifyStaleBalance()`).",
 						Destination: &specificValidator,
 					},
 				},

--- a/cli/main.go
+++ b/cli/main.go
@@ -49,6 +49,7 @@ func Require(flag *cli.StringFlag) *cli.StringFlag {
 // Destinations for values set by various flags
 var eigenpodAddress, beacon, node, sender, output string
 var useJson bool = false
+var specificValidator uint64 = math.MaxUint64
 
 // Required flags:
 
@@ -437,6 +438,11 @@ func main() {
 					EXEC_NODE_FLAG,
 					SENDER_PK_FLAG,
 					BatchBySize(&batchSize, DEFAULT_BATCH_CREDENTIALS),
+					&cli.Uint64Flag{
+						Name:        "validator",
+						Usage:       "The index of a specific validator to prove (e.g a slashed validator for `verifyStaleBalance()`).",
+						Destination: &specificValidator,
+					},
 				},
 				Action: func(cctx *cli.Context) error {
 					if disableColor {
@@ -446,7 +452,12 @@ func main() {
 					eth, beaconClient, chainId, err := core.GetClients(ctx, node, beacon)
 					core.PanicOnError("failed to reach ethereum clients", err)
 
-					validatorProofs, oracleBeaconTimestamp, err := core.GenerateValidatorProof(ctx, eigenpodAddress, eth, chainId, beaconClient)
+					var specificValidatorIndex *big.Int = nil
+					if specificValidator != math.MaxUint64 {
+						specificValidatorIndex = new(big.Int).SetUint64(specificValidator)
+					}
+
+					validatorProofs, oracleBeaconTimestamp, err := core.GenerateValidatorProof(ctx, eigenpodAddress, eth, chainId, beaconClient, specificValidatorIndex)
 					if err != nil || validatorProofs == nil {
 						core.PanicOnError("Failed to generate validator proof", err)
 						core.Panic("no inactive validators")


### PR DESCRIPTION
- We need this for `healthcheck` -- in order to call verifyStaleBalances, you need to be able to generate a credential proof against a specific validator. The normal command won't work for this because it filters validators based on statuses -- here you need to be able to generate the proof regardless of status.