### PR TITLE
Fix panic()'ing type assertion

### DIFF
--- a/cli/core/tracing.go
+++ b/cli/core/tracing.go
@@ -17,8 +17,8 @@ func ContextWithTracing(ctx context.Context, callbacks *TracerCallbacks) context
 }
 
 func GetContextTracingCallbacks(ctx context.Context) *TracerCallbacks {
-	tracing := ctx.Value(EIGEN_KEY).(*TracerCallbacks)
-	if tracing == nil {
+	tracing, ok := ctx.Value(EIGEN_KEY).(*TracerCallbacks)
+	if !ok || tracing == nil {
 		return &TracerCallbacks{
 			OnStartSection: func(name string, meta map[string]string) {},
 			OnEndSection:   func() {},


### PR DESCRIPTION
- `val, ok := .(*ptrtype)` syntax doesn't throw if the cast fails, it just returns ok as false.
- the previous syntax panics on a failed assertion, which occurs on null.


Not sure why none of us have repro'd this issue, but this should fix the problem.