### PR TITLE
Update Build Instructions

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,3 +1,0 @@
-all:
-	cd core && $(MAKE) all
-	go build

--- a/cli/README.md
+++ b/cli/README.md
@@ -5,16 +5,12 @@
 ## Dependencies
 
 - Golang >= 1.21
-- `abigen` (`go install github.com/ethereum/go-ethereum/cmd/abigen@latest`)
-- `jq` 
-- `solc` (`npm install -g solc`)
-
 - URL of an execution ETH node
 - URL of a beacon ETH node
 
 ## Building from source
 
->> `make`
+>> `go build`
 >> `./cli`
 
 # Proof Generation

--- a/cli/core/Makefile
+++ b/cli/core/Makefile
@@ -1,7 +1,5 @@
 TMP_DIR :=$(shell mktemp -d)
 
-.DEFAULT_GOAL := build
-
 all: codegen
 
 clone: 

--- a/cli/core/Makefile
+++ b/cli/core/Makefile
@@ -1,5 +1,7 @@
 TMP_DIR :=$(shell mktemp -d)
 
+.DEFAULT_GOAL := build
+
 all: codegen
 
 clone: 


### PR DESCRIPTION
- The additional dependencies aren't needed unless you're _contributing_ to the CLI.
- Removed all steps except `go build`, which is needed to build the binary.