### PR TITLE
`--print-calldata` for later proof submission

### DIFF
--- a/cli/core/checkpoint.go
+++ b/cli/core/checkpoint.go
@@ -20,7 +20,7 @@ import (
 	"github.com/fatih/color"
 )
 
-func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.VerifyCheckpointProofsCallParams, eth *ethclient.Client, batchSize uint64, noPrompt bool) ([]*types.Transaction, error) {
+func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.VerifyCheckpointProofsCallParams, eth *ethclient.Client, batchSize uint64, noPrompt bool, noSend bool) ([]*types.Transaction, error) {
 	tracing := GetContextTracingCallbacks(ctx)
 
 	allProofChunks := chunk(proof.BalanceProofs, batchSize)
@@ -32,7 +32,7 @@ func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, c
 		tracing.OnStartSection("pepe::proof::checkpoint::batch::submit", map[string]string{
 			"chunk": fmt.Sprintf("%d", i),
 		})
-		txn, err := SubmitCheckpointProofBatch(ctx, owner, eigenpodAddress, chainId, proof.ValidatorBalancesRootProof, balanceProofs, eth)
+		txn, err := SubmitCheckpointProofBatch(ctx, owner, eigenpodAddress, chainId, proof.ValidatorBalancesRootProof, balanceProofs, eth, noSend)
 		tracing.OnEndSection()
 		if err != nil {
 			// failed to submit batch.
@@ -52,10 +52,10 @@ func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, c
 	return transactions, nil
 }
 
-func SubmitCheckpointProofBatch(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.ValidatorBalancesRootProof, balanceProofs []*eigenpodproofs.BalanceProof, eth *ethclient.Client) (*types.Transaction, error) {
+func SubmitCheckpointProofBatch(ctx context.Context, owner, eigenpodAddress string, chainId *big.Int, proof *eigenpodproofs.ValidatorBalancesRootProof, balanceProofs []*eigenpodproofs.BalanceProof, eth *ethclient.Client, noSend bool) (*types.Transaction, error) {
 	tracing := GetContextTracingCallbacks(ctx)
 
-	ownerAccount, err := PrepareAccount(&owner, chainId)
+	ownerAccount, err := PrepareAccount(&owner, chainId, noSend)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/core/checkpoint.go
+++ b/cli/core/checkpoint.go
@@ -43,12 +43,19 @@ func SubmitCheckpointProof(ctx context.Context, owner, eigenpodAddress string, c
 		tracing.OnStartSection("pepe::proof::checkpoint::batch::wait", map[string]string{
 			"chunk": fmt.Sprintf("%d", i),
 		})
-		bind.WaitMined(ctx, eth, txn)
+
+		if !noSend {
+			bind.WaitMined(ctx, eth, txn)
+		}
 		tracing.OnEndSection()
 		color.Green("OK")
 	}
 
-	color.Green("Complete! re-run with `status` to see the updated Eigenpod state.")
+	if !noSend {
+		color.Green("Complete! re-run with `status` to see the updated Eigenpod state.")
+	} else {
+		color.Yellow("Submit these proofs to network and re-run with `status` to see the updated Eigenpod state.")
+	}
 	return transactions, nil
 }
 

--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -139,13 +139,11 @@ func StartCheckpoint(ctx context.Context, eigenpodAddress string, ownerPrivateKe
 		return nil, fmt.Errorf("failed to start checkpoint: %w", err)
 	}
 
-	color.Green("starting checkpoint: %s..", txn.Hash().Hex())
-
 	return txn, nil
 }
 
-func GetBeaconClient(beaconUri string) (BeaconClient, error) {
-	beaconClient, _, err := NewBeaconClient(beaconUri)
+func GetBeaconClient(beaconUri string, verbose bool) (BeaconClient, error) {
+	beaconClient, _, err := NewBeaconClient(beaconUri, verbose)
 	return beaconClient, err
 }
 
@@ -271,7 +269,7 @@ func GetCurrentCheckpointBlockRoot(eigenpodAddress string, eth *ethclient.Client
 	return &checkpoint.BeaconBlockRoot, nil
 }
 
-func GetClients(ctx context.Context, node, beaconNodeUri string) (*ethclient.Client, BeaconClient, *big.Int, error) {
+func GetClients(ctx context.Context, node, beaconNodeUri string, enableLogs bool) (*ethclient.Client, BeaconClient, *big.Int, error) {
 	eth, err := ethclient.Dial(node)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to reach eth --node: %w", err)
@@ -283,10 +281,10 @@ func GetClients(ctx context.Context, node, beaconNodeUri string) (*ethclient.Cli
 	}
 
 	if chainId == nil || chainId.Int64() != 17000 {
-		return nil, nil, nil, fmt.Errorf("This tool only supports the Holesky network.")
+		return nil, nil, nil, errors.New("this tool only supports the Holesky network")
 	}
 
-	beaconClient, err := GetBeaconClient(beaconNodeUri)
+	beaconClient, err := GetBeaconClient(beaconNodeUri, enableLogs)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to reach beacon client: %w", err)
 	}

--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -113,10 +113,11 @@ type Owner = struct {
 	FromAddress        gethCommon.Address
 	PublicKey          *ecdsa.PublicKey
 	TransactionOptions *bind.TransactOpts
+	IsDryRun           bool
 }
 
-func StartCheckpoint(ctx context.Context, eigenpodAddress string, ownerPrivateKey string, chainId *big.Int, eth *ethclient.Client, forceCheckpoint bool) (uint64, error) {
-	ownerAccount, err := PrepareAccount(&ownerPrivateKey, chainId)
+func StartCheckpoint(ctx context.Context, eigenpodAddress string, ownerPrivateKey string, chainId *big.Int, eth *ethclient.Client, forceCheckpoint bool, noSend bool) (uint64, error) {
+	ownerAccount, err := PrepareAccount(&ownerPrivateKey, chainId, noSend)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse private key: %w", err)
 	}
@@ -328,7 +329,7 @@ func PanicIfNoConsent(prompt string) {
 	}
 }
 
-func PrepareAccount(owner *string, chainID *big.Int) (*Owner, error) {
+func PrepareAccount(owner *string, chainID *big.Int, noSend bool) (*Owner, error) {
 	if owner == nil {
 		return nil, errors.New("no owner")
 	}
@@ -349,10 +350,13 @@ func PrepareAccount(owner *string, chainID *big.Int) (*Owner, error) {
 		return nil, err
 	}
 
+	auth.NoSend = noSend
+
 	return &Owner{
 		FromAddress:        fromAddress,
 		PublicKey:          publicKeyECDSA,
 		TransactionOptions: auth,
+		IsDryRun:           noSend,
 	}, nil
 }
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -1,0 +1,67 @@
+package main
+
+import cli "github.com/urfave/cli/v2"
+
+// Required for commands that need an EigenPod's address
+var POD_ADDRESS_FLAG = &cli.StringFlag{
+	Name:        "podAddress",
+	Aliases:     []string{"p", "pod"},
+	Value:       "",
+	Usage:       "[required] The onchain `address` of your eigenpod contract (0x123123123123)",
+	Required:    true,
+	Destination: &eigenpodAddress,
+}
+
+// Required for commands that need a beacon chain RPC
+var BEACON_NODE_FLAG = &cli.StringFlag{
+	Name:        "beaconNode",
+	Aliases:     []string{"b"},
+	Value:       "",
+	Usage:       "[required] `URL` to a functioning beacon node RPC (https://)",
+	Required:    true,
+	Destination: &beacon,
+}
+
+// Required for commands that need an execution layer RPC
+var EXEC_NODE_FLAG = &cli.StringFlag{
+	Name:        "execNode",
+	Aliases:     []string{"e"},
+	Value:       "",
+	Usage:       "[required] `URL` to a functioning execution-layer RPC (https://)",
+	Required:    true,
+	Destination: &node,
+}
+var PRINT_CALLDATA_BUT_DO_NOT_EXECUTE_FLAG = &cli.BoolFlag{
+	Name:        "print-calldata",
+	Value:       false,
+	Usage:       "Print the calldata for all associated transactions, but do not execute them. Note that some transactions have an order dependency (you cannot submit checkpoint proofs if you haven't started a checkpoint) so this may require you to get your pod into the correct state before usage.",
+	Required:    false,
+	Destination: &simulateTransaction,
+}
+
+// Optional commands:
+
+// Optional use for commands that want direct tx submission from a specific private key
+var SENDER_PK_FLAG = &cli.StringFlag{
+	Name:        "sender",
+	Aliases:     []string{"s"},
+	Value:       "",
+	Usage:       "`Private key` of the account that will send any transactions. If set, this will automatically submit the proofs to their corresponding onchain functions after generation. If using checkpoint mode, it will also begin a checkpoint if one hasn't been started already.",
+	Destination: &sender,
+}
+
+// Optional use for commands that support JSON output
+var PRINT_JSON_FLAG = &cli.BoolFlag{
+	Name:        "json",
+	Value:       false,
+	Usage:       "print only plain JSON",
+	Required:    false,
+	Destination: &useJson,
+}
+
+var PROOF_PATH_FLAG = &cli.StringFlag{
+	Name:        "proof",
+	Value:       "",
+	Usage:       "the `path` to a previous proof generated from this step (via -o proof.json). If provided, this proof will submitted to network via the --sender flag.",
+	Destination: &proofPath,
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -461,6 +461,7 @@ func main() {
 						txns, err := core.SubmitCheckpointProof(ctx, sender, eigenpodAddress, chainId, proof, eth, batchSize, noPrompt, simulateTransaction)
 						if simulateTransaction {
 							for i, txn := range txns {
+								color.Green("transaction(%d).to: %s", i, txn.To().Hex())
 								color.Green("transaction(%d).calldata: %s", i, hex.EncodeToString(txn.Data()))
 							}
 						} else {
@@ -540,6 +541,7 @@ func main() {
 						txns, err := core.SubmitValidatorProof(ctx, sender, eigenpodAddress, chainId, eth, batchSize, validatorProofs, oracleBeaconTimestamp, noPrompt, simulateTransaction)
 						if simulateTransaction {
 							for i, txn := range txns {
+								color.Green("transaction(%d).to: %s", i, txn.To().Hex())
 								color.Green("transaction(%d).calldata: %s", i, hex.EncodeToString(txn.Data()))
 							}
 						} else {

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Layr-Labs/eigenpod-proofs-generation/cli/core"
+	cli "github.com/urfave/cli/v2"
+)
+
+type Transaction struct {
+	Type     string `json:"type"`
+	To       string `json:"to"`
+	CallData string `json:"calldata"`
+}
+type TransactionList = []Transaction
+
+type CredentialProofTransaction struct {
+	Transaction
+	ValidatorIndices []uint64 `json:"validator_indices"`
+}
+
+func printProofs(txns any) {
+	out, err := json.Marshal(txns)
+	core.PanicOnError("failed to serialize proofs", err)
+	fmt.Println(string(out))
+}
+
+// imagine if golang had a standard library
+func aMap[A any, B any](coll []A, mapper func(i A) B) []B {
+	out := make([]B, len(coll))
+	for i, item := range coll {
+		out[i] = mapper(item)
+	}
+	return out
+}
+
+func aFlatten[A any](coll [][]A) []A {
+	out := []A{}
+	for _, arr := range coll {
+		for _, item := range arr {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func shortenHex(publicKey string) string {
+	return publicKey[0:6] + ".." + publicKey[len(publicKey)-4:]
+}
+
+// shared flag --batch
+func BatchBySize(destination *uint64, defaultValue uint64) *cli.Uint64Flag {
+	return &cli.Uint64Flag{
+		Name:        "batch",
+		Value:       defaultValue,
+		Usage:       "Submit proofs in groups of size `batchSize`, to avoid gas limit.",
+		Required:    false,
+		Destination: destination,
+	}
+}
+
+// Hack to make a copy of a flag that sets `Required` to true
+func Require(flag *cli.StringFlag) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:        flag.Name,
+		Aliases:     flag.Aliases,
+		Value:       flag.Value,
+		Usage:       flag.Usage,
+		Destination: flag.Destination,
+		Required:    true,
+	}
+}


### PR DESCRIPTION
# Summary

- If `--print-calldata` is specified during the `credentials` or `checkpoint` command, we will prepare the transaction(s) without sending, and print the calldata as structured JSON.
- For checkpoint proofs, we will print the calldata to start the checkpoint if one is not active yet. if one is already active, we will print the calldata for the proofs, batched according to `--batchSize`.

The proofs will be printed with (TO) and (CALLDATA) fields, all hex encoded. Credential proofs include `validator_indices`, which is an array of validator indices to be attested in that proof. You should submit the sequentially to network, taking care of your nonces as needed. They may be submitted by either the Eigenpod's owner, or an approved proof submitter (see `assign-submitter` command).

## Approach

We use the `NoSend` option in abigen, and combine it with a burner ETH wallet. I've hardcoded the PK of an eth wallet into the script -- the signed data is never used anyways.

# Data Format
You should expect either an array of Transaction, or an array of CredentialProofTransaction

<img width="319" alt="image" src="https://github.com/user-attachments/assets/c158aa94-a5d2-4248-b214-460f1d62b2a8">


# Example Command
`./cli checkpoint --podAddress $EIGENPOD_ADDRESS --beaconNode $NODE_BEACON --execNode $NODE_ETH  --print-calldata`

# Submitting to network

You can use the `cast` tool to submit these proofs to network.

`cast send $TO $CALLDATA --rpc-url $NODE_ETH --private-key $EIGENPOD_PK `

# Testing
## checkpoint
<img width="835" alt="image" src="https://github.com/user-attachments/assets/61e6a9af-2a56-4448-95b8-48e35f947784">
## credentials
<img width="1307" alt="image" src="https://github.com/user-attachments/assets/b554a462-40d7-44d5-8940-b4dcc4fd243f">

# Test transactions
- [startCheckpoint](https://holesky.etherscan.io/tx/0x9c63b1d32823d07ed2e5207a37432a2ad19682ff29ba96a1df73a9057abbfee1)
- [verifyCheckpointProofs](https://holesky.etherscan.io/tx/0x9f0050eb2783361ab1850b58448abc3c340a50b19d8e5c180c825d24139e27d8)


