### PR TITLE
[bugfix] issue with `credentials` command

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -492,8 +492,9 @@ func main() {
 					core.PanicOnError("failed to reach ethereum clients", err)
 
 					var specificValidatorIndex *big.Int = nil
-					if specificValidator != math.MaxUint64 {
+					if specificValidator != math.MaxUint64 && specificValidator != 0 {
 						specificValidatorIndex = new(big.Int).SetUint64(specificValidator)
+						fmt.Printf("Using specific validator: %d", specificValidator)
 					}
 
 					if len(proofPath) > 0 {


### PR DESCRIPTION
- `specificValidator` defaults to `0`, not to max int. 
- Check both cases, just in case.

This whole suite needs to be tested aggressively for issues like this, and to prevent regressions. We will invest in this in the coming week or two.