### PR TITLE
Support `--start-only` for `checkpoint` command.

### DIFF
--- a/cli/commands/checkpoint.go
+++ b/cli/commands/checkpoint.go
@@ -23,6 +23,7 @@ type TCheckpointCommandArgs struct {
 	BatchSize           uint64
 	ForceCheckpoint     bool
 	Verbose             bool
+	StartCheckpointOnly bool
 }
 
 func CheckpointCommand(args TCheckpointCommandArgs) error {
@@ -80,6 +81,10 @@ func CheckpointCommand(args TCheckpointCommandArgs) error {
 		} else {
 			core.PanicOnError("no checkpoint active and no private key provided to start one", errors.New("no checkpoint"))
 		}
+	} else if args.StartCheckpointOnly {
+		// there is already an ongoing checkpoint.
+		core.Panic("--start-only provided, but a checkpoint was already in progress")
+		return nil
 	}
 
 	if isVerbose {

--- a/cli/main.go
+++ b/cli/main.go
@@ -17,7 +17,7 @@ var specificValidator uint64 = math.MaxUint64
 func main() {
 	var batchSize uint64
 	var forceCheckpoint, disableColor, verbose bool
-	var noPrompt bool
+	var noPrompt, startCheckpointOnly bool
 
 	app := &cli.App{
 		Name:                   "Eigenlayer Proofs CLi",
@@ -84,6 +84,12 @@ func main() {
 						Usage:       "If true, starts a checkpoint even if the pod has no native ETH to award shares",
 						Destination: &forceCheckpoint,
 					},
+					&cli.BoolFlag{
+						Name:        "start-only",
+						Value:       false,
+						Usage:       "If true, will only ever attempt to start a checkpoint. (will not attempt to generate/subit proofs in any capacity)",
+						Destination: &startCheckpointOnly,
+					},
 				},
 				Action: func(cctx *cli.Context) error {
 					return commands.CheckpointCommand(commands.TCheckpointCommandArgs{
@@ -97,6 +103,7 @@ func main() {
 						EigenpodAddress:     eigenpodAddress,
 						Verbose:             verbose,
 						Sender:              sender,
+						StartCheckpointOnly: startCheckpointOnly,
 					})
 				},
 			},


### PR DESCRIPTION
`--start-only` will attempt to start a checkpoint (calling out to network if `--sender` is provided, or printing `to/calldata` otherwise).
- If a checkpoint is already in flight, this command results in an error / non-zero exit code.