### PR TITLE
Enable golang linters

### DIFF
--- a/.github/lint.sh
+++ b/.github/lint.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/bash
-
-make lint

--- a/.github/lint.sh
+++ b/.github/lint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,8 @@ jobs:
 
     - name: Set up Go 1.22
       uses: actions/setup-go@v1
+      env:
+        GOPATH: /home/runner/.go
       with:
         go-version: 1.22.4
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Run Lint
       env:
         GOPATH: /home/runner/.go
-      run: /home/runner/.go/bin/golangci-lint run
+      run: /home/runner/.go/bin/golangci-lint run ./cli

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+
+on: 
+  push:
+    branches: 
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: |
+        make setup
+
+    - name: Run Lint
+      run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Run Lint
       env:
         GOPATH: /home/runner/.go
-      run: ./.github/lint.sh
+      run: /home/runner/.go/bin/golangci-lint run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
     - name: Install dependencies
       run: |
         make setup
+        go env
+        ls -lar $GOPATH
 
     - name: Run Lint
       run: ./.github/lint.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,4 @@ jobs:
         make setup
 
     - name: Run Lint
-      run: make lint
+      run: ./.github/lint.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,11 +14,21 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
+    - name: Set up Go 1.22
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.22.4
+
     - name: Install dependencies
+      env:
+        GOPATH: ~/.go
       run: |
+        mkdir ~/.go
         make setup
         go env
         ls -lar $GOPATH
 
     - name: Run Lint
+      env:
+        GOPATH: ~/.go
       run: ./.github/lint.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,14 +21,14 @@ jobs:
 
     - name: Install dependencies
       env:
-        GOPATH: ~/.go
+        GOPATH: /home/runner/.go
       run: |
-        mkdir ~/.go
+        mkdir /home/runner/.go
         make setup
         go env
         ls -lar $GOPATH
 
     - name: Run Lint
       env:
-        GOPATH: ~/.go
+        GOPATH: /home/runner/.go
       run: ./.github/lint.sh

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,4 +53,4 @@ linters:
     - whitespace
 
 run:
-  issues-exit-code: 1
+  issues-exit-code: 2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,56 @@
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+  goconst:
+    min-len: 2
+    min-occurrences: 3
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+  govet:
+    check-shadowing: true
+    enable:
+      - fieldalignment
+  nolintlint:
+    require-explanation: true
+    require-specific: true
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - goconst
+    - gocritic
+    - gofmt
+    - gomnd
+    - gocyclo
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nolintlint
+    - nakedret
+    - prealloc
+    - predeclared
+    - revive
+    - staticcheck
+    - stylecheck
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - whitespace
+
+run:
+  issues-exit-code: 1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+setup:
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
+lint:
+	golangci-lint run ./cli
+
+lint-fix:
+	golangci-lint run ./cli --fix

--- a/beacon/beacon_state_top_level_roots.go
+++ b/beacon/beacon_state_top_level_roots.go
@@ -45,7 +45,6 @@ func ProveBeaconTopLevelRootAgainstBeaconState(beaconTopLevelRoots *BeaconStateT
 		r := v.Field(i).Interface()
 		typedR := r.(*phase0.Root)
 		beaconTopLevelRootsList[i] = *typedR
-
 	}
 	roots := make([]phase0.Root, len(beaconTopLevelRootsList))
 	for i, v := range beaconTopLevelRootsList {

--- a/beacon/block.go
+++ b/beacon/block.go
@@ -8,7 +8,6 @@ import (
 
 // refer to this: https://github.com/attestantio/go-eth2-client/blob/654ac05b4c534d96562329f988655e49e5743ff5/spec/phase0/beaconblockheader_encoding.go
 func ProveStateRootAgainstBlockHeader(b *phase0.BeaconBlockHeader) (common.Proof, error) {
-
 	beaconBlockHeaderContainerRoots, err := GetBlockHeaderFieldRoots(b)
 	if err != nil {
 		return nil, err

--- a/beacon/deneb.go
+++ b/beacon/deneb.go
@@ -10,7 +10,6 @@ import (
 
 // taken from https://github.com/attestantio/go-eth2-client/blob/21f7dd480fed933d8e0b1c88cee67da721c80eb2/spec/deneb/beaconstate_ssz.go#L640
 func ComputeBeaconStateTopLevelRootsDeneb(b *deneb.BeaconState) (*BeaconStateTopLevelRoots, error) {
-
 	var err error
 	beaconStateTopLevelRoots := &BeaconStateTopLevelRoots{}
 

--- a/beacon/shared.go
+++ b/beacon/shared.go
@@ -29,7 +29,7 @@ func ComputeValidatorBalancesTreeLeaves(balances []phase0.Gwei) []phase0.Root {
 	for i := 0; i < len(balances); i++ {
 		buf = ssz.MarshalUint64(buf, uint64(balances[i]))
 	}
-	//pad the buffer with 0s to make it a multiple of 32 bytes
+	// pad the buffer with 0s to make it a multiple of 32 bytes
 	if rest := len(buf) % 32; rest != 0 {
 		buf = append(buf, zeroBytes[:32-rest]...)
 	}
@@ -51,7 +51,7 @@ func GetValidatorBalancesProofDepth(numBalances int) uint64 {
 func ProveValidatorBalanceAgainstValidatorBalanceList(balances []phase0.Gwei, validatorIndex uint64) (phase0.Root, common.Proof, error) {
 	balanceRootList := ComputeValidatorBalancesTreeLeaves(balances)
 
-	//refer to beaconstate_ssz.go in go-eth2-client
+	// refer to beaconstate_ssz.go in go-eth2-client
 	numLayers := uint64(common.GetDepth(ssz.CalculateLimit(1099511627776, uint64(len(balances)), 8)))
 	validatorBalanceIndex := uint64(validatorIndex / 4)
 	proof, err := common.GetProof(balanceRootList, validatorBalanceIndex, numLayers)
@@ -60,8 +60,8 @@ func ProveValidatorBalanceAgainstValidatorBalanceList(balances []phase0.Gwei, va
 		return phase0.Root{}, nil, err
 	}
 
-	//append the length of the balance array to the proof
-	//convert big endian to little endian
+	// append the length of the balance array to the proof
+	// convert big endian to little endian
 	balanceListLenLE := common.BigToLittleEndian(big.NewInt(int64(len(balances))))
 
 	proof = append(proof, balanceListLenLE)

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -37,7 +37,6 @@ func BenchmarkComputeBeaconStateTopLevelRoots(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-
 	}
 	assert.Equal(b, computed, cached)
 }

--- a/cli/commands/status.go
+++ b/cli/commands/status.go
@@ -105,7 +105,6 @@ func StatusCommand(args TStatusArgs) error {
 				} else {
 					targetColor.Printf("\t- #%d (%s) [%d] [%d]\n", validator.Index, publicKey, validator.EffectiveBalance, validator.CurrentBalance)
 				}
-
 			}
 
 			fmt.Println()

--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -156,7 +156,6 @@ func GetCurrentCheckpoint(eigenpodAddress string, client *ethclient.Client) (uin
 	timestamp, err := eigenPod.CurrentCheckpointTimestamp(nil)
 	if err != nil {
 		return 0, fmt.Errorf("failed to locate eigenpod. Is your address correct?: %w", err)
-
 	}
 
 	return timestamp, nil
@@ -214,7 +213,7 @@ func FindAllValidatorsForEigenpod(eigenpodAddress string, beaconState *spec.Vers
 		}
 		// we check that the last 20 bytes of expectedCredentials matches validatorCredentials.
 		if bytes.Equal(
-			eigenpodAddressBytes[:],
+			eigenpodAddressBytes,
 			validator.WithdrawalCredentials[12:], // first 12 bytes are not the pubKeyHash, see (https://github.com/Layr-Labs/eigenlayer-contracts/blob/d148952a2942a97a218a2ab70f9b9f1792796081/src/contracts/pods/EigenPod.sol#L663)
 		) {
 			outputValidators = append(outputValidators, ValidatorWithIndex{

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -3,7 +3,7 @@ package main
 import cli "github.com/urfave/cli/v2"
 
 // Required for commands that need an EigenPod's address
-var POD_ADDRESS_FLAG = &cli.StringFlag{
+var PodAddressFlag = &cli.StringFlag{
 	Name:        "podAddress",
 	Aliases:     []string{"p", "pod"},
 	Value:       "",
@@ -13,7 +13,7 @@ var POD_ADDRESS_FLAG = &cli.StringFlag{
 }
 
 // Required for commands that need a beacon chain RPC
-var BEACON_NODE_FLAG = &cli.StringFlag{
+var BeaconNodeFlag = &cli.StringFlag{
 	Name:        "beaconNode",
 	Aliases:     []string{"b"},
 	Value:       "",
@@ -23,7 +23,7 @@ var BEACON_NODE_FLAG = &cli.StringFlag{
 }
 
 // Required for commands that need an execution layer RPC
-var EXEC_NODE_FLAG = &cli.StringFlag{
+var ExecNodeFlag = &cli.StringFlag{
 	Name:        "execNode",
 	Aliases:     []string{"e"},
 	Value:       "",
@@ -35,7 +35,7 @@ var EXEC_NODE_FLAG = &cli.StringFlag{
 // Optional commands:
 
 // Optional use for commands that want direct tx submission from a specific private key
-var SENDER_PK_FLAG = &cli.StringFlag{
+var SenderPkFlag = &cli.StringFlag{
 	Name:        "sender",
 	Aliases:     []string{"s"},
 	Value:       "",
@@ -44,12 +44,12 @@ var SENDER_PK_FLAG = &cli.StringFlag{
 }
 
 // Optional use for commands that support JSON output
-var PRINT_JSON_FLAG = &cli.BoolFlag{
+var PrintJSONFlag = &cli.BoolFlag{
 	Name:        "json",
 	Value:       false,
 	Usage:       "print only plain JSON",
 	Required:    false,
-	Destination: &useJson,
+	Destination: &useJSON,
 }
 
 // shared flag --batch

--- a/cli/main.go
+++ b/cli/main.go
@@ -11,13 +11,15 @@ import (
 
 // Destinations for values set by various flags
 var eigenpodAddress, beacon, node, sender string
-var useJson bool = false
+var useJSON = false
 var specificValidator uint64 = math.MaxUint64
 
 func main() {
 	var batchSize uint64
-	var forceCheckpoint, disableColor, verbose bool
-	var noPrompt bool
+	var forceCheckpoint = false
+	var disableColor = false
+	var verbose = false
+	var noPrompt = false
 
 	app := &cli.App{
 		Name:                   "Eigenlayer Proofs CLi",
@@ -32,9 +34,9 @@ func main() {
 				Usage:     "Assign a different address to be able to submit your proofs. You'll always be able to submit from your EigenPod owner PK.",
 				UsageText: "./cli assign-submitter [FLAGS] <0xsubmitter>",
 				Flags: []cli.Flag{
-					POD_ADDRESS_FLAG,
-					EXEC_NODE_FLAG,
-					Require(SENDER_PK_FLAG),
+					PodAddressFlag,
+					ExecNodeFlag,
+					Require(SenderPkFlag),
 				},
 				Action: func(cctx *cli.Context) error {
 					return commands.AssignSubmitterCommand(commands.TAssignSubmitterArgs{
@@ -51,16 +53,16 @@ func main() {
 				Name:  "status",
 				Usage: "Checks the status of your eigenpod.",
 				Flags: []cli.Flag{
-					POD_ADDRESS_FLAG,
-					BEACON_NODE_FLAG,
-					EXEC_NODE_FLAG,
-					PRINT_JSON_FLAG,
+					PodAddressFlag,
+					BeaconNodeFlag,
+					ExecNodeFlag,
+					PrintJSONFlag,
 				},
-				Action: func(cctx *cli.Context) error {
+				Action: func(_ *cli.Context) error {
 					return commands.StatusCommand(commands.TStatusArgs{
 						EigenpodAddress: eigenpodAddress,
 						DisableColor:    disableColor,
-						UseJSON:         useJson,
+						UseJSON:         useJSON,
 						Node:            node,
 						BeaconNode:      beacon,
 						Verbose:         verbose,
@@ -72,10 +74,10 @@ func main() {
 				Aliases: []string{"cp"},
 				Usage:   "Generates a proof for use with EigenPod.verifyCheckpointProofs().",
 				Flags: []cli.Flag{
-					POD_ADDRESS_FLAG,
-					BEACON_NODE_FLAG,
-					EXEC_NODE_FLAG,
-					SENDER_PK_FLAG,
+					PodAddressFlag,
+					BeaconNodeFlag,
+					ExecNodeFlag,
+					SenderPkFlag,
 					BatchBySize(&batchSize, utils.DEFAULT_BATCH_CHECKPOINT),
 					&cli.BoolFlag{
 						Name:        "force",
@@ -85,11 +87,11 @@ func main() {
 						Destination: &forceCheckpoint,
 					},
 				},
-				Action: func(cctx *cli.Context) error {
+				Action: func(_ *cli.Context) error {
 					return commands.CheckpointCommand(commands.TCheckpointCommandArgs{
 						DisableColor:        disableColor,
 						NoPrompt:            noPrompt,
-						SimulateTransaction: len(sender) == 0,
+						SimulateTransaction: sender == "",
 						BatchSize:           batchSize,
 						ForceCheckpoint:     forceCheckpoint,
 						Node:                node,
@@ -105,10 +107,10 @@ func main() {
 				Aliases: []string{"cr", "creds"},
 				Usage:   "Generates a proof for use with EigenPod.verifyWithdrawalCredentials()",
 				Flags: []cli.Flag{
-					POD_ADDRESS_FLAG,
-					BEACON_NODE_FLAG,
-					EXEC_NODE_FLAG,
-					SENDER_PK_FLAG,
+					PodAddressFlag,
+					BeaconNodeFlag,
+					ExecNodeFlag,
+					SenderPkFlag,
 					BatchBySize(&batchSize, utils.DEFAULT_BATCH_CREDENTIALS),
 					&cli.Uint64Flag{
 						Name:        "validatorIndex",
@@ -116,12 +118,12 @@ func main() {
 						Destination: &specificValidator,
 					},
 				},
-				Action: func(cctx *cli.Context) error {
+				Action: func(_ *cli.Context) error {
 					return commands.CredentialsCommand(commands.TCredentialCommandArgs{
 						EigenpodAddress:     eigenpodAddress,
 						DisableColor:        disableColor,
-						UseJSON:             useJson,
-						SimulateTransaction: len(sender) == 0,
+						UseJSON:             useJSON,
+						SimulateTransaction: sender == "",
 						Node:                node,
 						BeaconNode:          beacon,
 						Sender:              sender,

--- a/common/merkle_utils.go
+++ b/common/merkle_utils.go
@@ -1,6 +1,6 @@
 package common
 
-//Adapted from https://github.com/ferranbt/fastssz/blob/main/tree.go
+// Adapted from https://github.com/ferranbt/fastssz/blob/main/tree.go
 import (
 	"encoding/hex"
 	"encoding/json"
@@ -90,27 +90,22 @@ func ComputeMerkleTreeFromLeaves(values []phase0.Root, numLayers uint64) ([][]ph
 
 	for l := 0; l < int(numLayers); l++ {
 		if len(tree[l])%2 == 1 {
-
 			zeroHash := phase0.Root(zeroHashes[l])
 			tree[l] = append(tree[l], zeroHash)
 		}
 		nextLevelSize := len(tree[l]) / 2
 		values := make([]phase0.Root, nextLevelSize)
 		for i := 0; i < len(tree[l]); i += 2 {
-
 			values[i/2] = hashNodes(tree[l][i], tree[l][i+1])
-
 		}
 		tree[l+1] = values
 	}
 
 	return tree, nil
-
 }
 
 // This proof is from the bottom to the top
 func ComputeMerkleProofFromTree(tree [][]phase0.Root, index, numLayers uint64) (Proof, error) {
-
 	var proof [][32]byte
 	for l := 0; l < int(numLayers); l++ {
 		if len(tree[l]) == 0 {
@@ -137,7 +132,6 @@ func hashFn(data []byte) [32]byte {
 }
 
 func GetProof(leaves []phase0.Root, index uint64, numLayers uint64) (Proof, error) {
-
 	tree, err := ComputeMerkleTreeFromLeaves(leaves, numLayers)
 	if err != nil {
 		fmt.Println("error in get proof tree", err)
@@ -145,7 +139,7 @@ func GetProof(leaves []phase0.Root, index uint64, numLayers uint64) (Proof, erro
 		return nil, err
 	}
 
-	//LogTreeByLevel(tree)
+	// LogTreeByLevel(tree)
 
 	proof, err := ComputeMerkleProofFromTree(tree, index, numLayers)
 

--- a/eigen_pod_proofs.go
+++ b/eigen_pod_proofs.go
@@ -91,7 +91,7 @@ func (epp *EigenPodProofs) ComputeBeaconStateRoot(beaconState *deneb.BeaconState
 }
 
 func (epp *EigenPodProofs) ComputeBeaconStateTopLevelRoots(beaconState *spec.VersionedBeaconState) (*beacon.BeaconStateTopLevelRoots, error) {
-	//get the versioned beacon state's slot
+	// get the versioned beacon state's slot
 	slot, err := beaconState.Slot()
 	if err != nil {
 		return nil, err

--- a/prove_validator.go
+++ b/prove_validator.go
@@ -187,8 +187,8 @@ func (epp *EigenPodProofs) proveValidatorAgainstValidatorList(slot phase0.Slot, 
 	if err != nil {
 		return nil, err
 	}
-	//append the length of the validator array to the proof
-	//convert big endian to little endian
+	// append the length of the validator array to the proof
+	// convert big endian to little endian
 	validatorListLenLE := BigToLittleEndian(big.NewInt(int64(len(validators))))
 
 	proof = append(proof, validatorListLenLE)

--- a/prove_validator_test.go
+++ b/prove_validator_test.go
@@ -96,7 +96,6 @@ func verifyValidatorBalancesRootAgainstBlockHeader(t *testing.T, epp *eigenpodpr
 }
 
 func verifyValidatorBalanceAgainstValidatorBalancesRoot(t *testing.T, epp *eigenpodproofs.EigenPodProofs, oracleState *deneb.BeaconState, validatorBalancesRoot phase0.Root, proof *eigenpodproofs.BalanceProof, validatorIndex uint64) bool {
-
 	index := beacon.BALANCES_INDEX<<(beacon.GetValidatorBalancesProofDepth(len(oracleState.Balances))+1) | (validatorIndex / 4)
 
 	return common.ValidateProof(validatorBalancesRoot, proof.Proof, proof.BalanceRoot, index)


### PR DESCRIPTION
- enable `golangci-lint`, which tests for a variety of linter issues.
- right now it's scoped just to `./cli`, but we should enable for the whole repo.