### PR TITLE
Support `--gas` for gas estimation

### DIFF
--- a/cli/commands/utils.go
+++ b/cli/commands/utils.go
@@ -8,9 +8,10 @@ import (
 )
 
 type Transaction struct {
-	Type     string `json:"type"`
-	To       string `json:"to"`
-	CallData string `json:"calldata"`
+	Type            string  `json:"type"`
+	To              string  `json:"to"`
+	CallData        string  `json:"calldata"`
+	GasEstimateGwei *uint64 `json:"gas_estimate_gwei,omitempty"`
 }
 type TransactionList = []Transaction
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -43,6 +43,14 @@ var SenderPkFlag = &cli.StringFlag{
 	Destination: &sender,
 }
 
+var EstimateGasFlag = &cli.BoolFlag{
+	Name:        "gas",
+	Aliases:     []string{"g"},
+	Value:       false,
+	Usage:       "Estimate gas on the transaction (using `--sender` as the sender for simulation). This will NOT send the transaction.",
+	Destination: &estimateGas,
+}
+
 // Optional use for commands that support JSON output
 var PrintJSONFlag = &cli.BoolFlag{
 	Name:        "json",

--- a/cli/main.go
+++ b/cli/main.go
@@ -13,6 +13,7 @@ import (
 var eigenpodAddress, beacon, node, sender string
 var useJSON = false
 var specificValidator uint64 = math.MaxUint64
+var estimateGas bool = false
 
 func main() {
 	var batchSize uint64
@@ -78,6 +79,7 @@ func main() {
 					BeaconNodeFlag,
 					ExecNodeFlag,
 					SenderPkFlag,
+					EstimateGasFlag,
 					BatchBySize(&batchSize, utils.DEFAULT_BATCH_CHECKPOINT),
 					&cli.BoolFlag{
 						Name:        "force",
@@ -91,7 +93,7 @@ func main() {
 					return commands.CheckpointCommand(commands.TCheckpointCommandArgs{
 						DisableColor:        disableColor,
 						NoPrompt:            noPrompt,
-						SimulateTransaction: sender == "",
+						SimulateTransaction: sender == "" || estimateGas,
 						BatchSize:           batchSize,
 						ForceCheckpoint:     forceCheckpoint,
 						Node:                node,
@@ -111,6 +113,7 @@ func main() {
 					BeaconNodeFlag,
 					ExecNodeFlag,
 					SenderPkFlag,
+					EstimateGasFlag,
 					BatchBySize(&batchSize, utils.DEFAULT_BATCH_CREDENTIALS),
 					&cli.Uint64Flag{
 						Name:        "validatorIndex",
@@ -123,7 +126,7 @@ func main() {
 						EigenpodAddress:     eigenpodAddress,
 						DisableColor:        disableColor,
 						UseJSON:             useJSON,
-						SimulateTransaction: sender == "",
+						SimulateTransaction: sender == "" || estimateGas,
 						Node:                node,
 						BeaconNode:          beacon,
 						Sender:              sender,


### PR DESCRIPTION
- If you provide `--sender <pk> --gas`, we'll simulate the transaction for you and print out a `gas_estimation` field in the JSON that you can use to understand the costs associated with submitting a transaction. Here are some examples;
- This works for both the `credentials` and `checkpoint` commands :) 

<img width="1418" alt="image" src="https://github.com/user-attachments/assets/78ce3c42-b390-482a-88e7-3b264890f0c5">

<img width="1344" alt="image" src="https://github.com/user-attachments/assets/d49ffd19-c9fe-405d-a1f8-42c152d8faf3">

