### PR TITLE
Update `find-stale-pods` logic

### DIFF
--- a/cli/commands/checkpoint.go
+++ b/cli/commands/checkpoint.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Layr-Labs/eigenpod-proofs-generation/cli/core"
 	"github.com/Layr-Labs/eigenpod-proofs-generation/cli/core/onchain"
+	"github.com/Layr-Labs/eigenpod-proofs-generation/cli/utils"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -94,7 +95,7 @@ func CheckpointCommand(args TCheckpointCommandArgs) error {
 
 	txns, err := core.SubmitCheckpointProof(ctx, args.Sender, args.EigenpodAddress, chainId, proof, eth, args.BatchSize, args.NoPrompt, args.SimulateTransaction)
 	if args.SimulateTransaction {
-		printableTxns := aMap(txns, func(txn *types.Transaction) Transaction {
+		printableTxns := utils.Map(txns, func(txn *types.Transaction, _ uint64) Transaction {
 			return Transaction{
 				To:       txn.To().Hex(),
 				CallData: common.Bytes2Hex(txn.Data()),

--- a/cli/commands/credentials.go
+++ b/cli/commands/credentials.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 
 	"github.com/Layr-Labs/eigenpod-proofs-generation/cli/core"
+	"github.com/Layr-Labs/eigenpod-proofs-generation/cli/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/fatih/color"
@@ -65,7 +66,7 @@ func CredentialsCommand(args TCredentialCommandArgs) error {
 		}()), err)
 
 		if args.SimulateTransaction {
-			out := aMap(txns, func(txn *types.Transaction) CredentialProofTransaction {
+			out := utils.Map(txns, func(txn *types.Transaction, _ uint64) CredentialProofTransaction {
 				gas := txn.Gas()
 				return CredentialProofTransaction{
 					Transaction: Transaction{
@@ -79,7 +80,7 @@ func CredentialsCommand(args TCredentialCommandArgs) error {
 							return nil
 						}(),
 					},
-					ValidatorIndices: aMap(aFlatten(indices), func(index *big.Int) uint64 {
+					ValidatorIndices: utils.Map(utils.Flatten(indices), func(index *big.Int, _ uint64) uint64 {
 						return index.Uint64()
 					}),
 				}

--- a/cli/commands/staleBalance.go
+++ b/cli/commands/staleBalance.go
@@ -18,7 +18,7 @@ type TFixStaleBalanceArgs struct {
 	BeaconNode            string
 	Sender                string
 	EigenpodAddress       string
-	SlashedValidatorIndex int64
+	SlashedValidatorIndex uint64
 	Verbose               bool
 	CheckpointBatchSize   uint64
 	NoPrompt              bool
@@ -39,7 +39,7 @@ func FixStaleBalance(args TFixStaleBalanceArgs) error {
 	eth, beacon, chainId, err := core.GetClients(ctx, args.EthNode, args.BeaconNode, args.Verbose)
 	core.PanicOnError("failed to get clients", err)
 
-	validator, err := beacon.GetValidator(ctx, uint64(args.SlashedValidatorIndex))
+	validator, err := beacon.GetValidator(ctx, args.SlashedValidatorIndex)
 	core.PanicOnError("failed to fetch validator state", err)
 
 	if !validator.Validator.Slashed {
@@ -75,7 +75,7 @@ func FixStaleBalance(args TFixStaleBalanceArgs) error {
 		}
 	}
 
-	proof, oracleBeaconTimesetamp, err := core.GenerateValidatorProof(ctx, args.EigenpodAddress, eth, chainId, beacon, new(big.Int).SetUint64(uint64(args.SlashedValidatorIndex)), args.Verbose)
+	proof, oracleBeaconTimesetamp, err := core.GenerateValidatorProof(ctx, args.EigenpodAddress, eth, chainId, beacon, new(big.Int).SetUint64(args.SlashedValidatorIndex), args.Verbose)
 	core.PanicOnError("failed to generate credential proof for slashed validator", err)
 
 	if !args.NoPrompt {

--- a/cli/commands/status.go
+++ b/cli/commands/status.go
@@ -74,7 +74,7 @@ func StatusCommand(args TStatusArgs) error {
 			for _, validator := range awaitingActivationQueueValidators {
 				publicKey := validator.PublicKey
 				if !isVerbose {
-					publicKey = shortenHex(publicKey)
+					publicKey = utils.ShortenHex(publicKey)
 				}
 
 				targetColor = color.New(color.FgHiRed)
@@ -97,7 +97,7 @@ func StatusCommand(args TStatusArgs) error {
 			for _, validator := range inactiveValidators {
 				publicKey := validator.PublicKey
 				if !isVerbose {
-					publicKey = shortenHex(publicKey)
+					publicKey = utils.ShortenHex(publicKey)
 				}
 
 				if validator.Slashed {
@@ -120,7 +120,7 @@ func StatusCommand(args TStatusArgs) error {
 			for _, validator := range activeValidators {
 				publicKey := validator.PublicKey
 				if !isVerbose {
-					publicKey = shortenHex(publicKey)
+					publicKey = utils.ShortenHex(publicKey)
 				}
 
 				if validator.Slashed {
@@ -143,7 +143,7 @@ func StatusCommand(args TStatusArgs) error {
 			for _, validator := range withdrawnValidators {
 				publicKey := validator.PublicKey
 				if !isVerbose {
-					publicKey = shortenHex(publicKey)
+					publicKey = utils.ShortenHex(publicKey)
 				}
 
 				if validator.Slashed {

--- a/cli/commands/utils.go
+++ b/cli/commands/utils.go
@@ -25,24 +25,3 @@ func printProofs(txns any) {
 	core.PanicOnError("failed to serialize proofs", err)
 	fmt.Println(string(out))
 }
-
-// imagine if golang had a standard library
-func aMap[A any, B any](coll []A, mapper func(i A) B) []B {
-	out := make([]B, len(coll))
-	for i, item := range coll {
-		out[i] = mapper(item)
-	}
-	return out
-}
-
-func aFlatten[A any](coll [][]A) []A {
-	out := []A{}
-	for _, arr := range coll {
-		out = append(out, arr...)
-	}
-	return out
-}
-
-func shortenHex(publicKey string) string {
-	return publicKey[0:6] + ".." + publicKey[len(publicKey)-4:]
-}

--- a/cli/core/findStalePods.go
+++ b/cli/core/findStalePods.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/pkg/errors"
 )
 
@@ -21,6 +22,10 @@ func PodManagerContracts() map[uint64]string {
 		0:     "0x91E677b07F7AF907ec9a428aafA9fc14a0d3A338",
 		17000: "0x30770d7E3e71112d7A6b7259542D1f680a70e315", //testnet holesky
 	}
+}
+
+func weiToGwei(val uint64) phase0.Gwei {
+	return phase0.Gwei(new(big.Int).Div(new(big.Int).SetUint64(val), big.NewInt(params.GWei)).Uint64())
 }
 
 type Cache struct {
@@ -109,7 +114,7 @@ func isEigenpod(eth *ethclient.Client, chainId uint64, eigenpodAddress string) (
 	// Implement contract fetching logic here
 	cache.PodOwnerShares[eigenpodAddress] = PodOwnerShare{
 		Shares:     podOwnerShares.Uint64(),
-		NativeETH:  phase0.Gwei(balance.Uint64()),
+		NativeETH:  weiToGwei(balance.Uint64()),
 		IsEigenpod: true,
 	}
 

--- a/cli/core/findStalePods.go
+++ b/cli/core/findStalePods.go
@@ -234,8 +234,7 @@ func FindStaleEigenpods(ctx context.Context, eth *ethclient.Client, nodeUrl stri
 			return accum + allValidatorBalances[validator.Index]
 		}, phase0.Gwei(0))
 
-		balance := phase0.Gwei(cache.PodOwnerShares[eigenpod].ExecutionLayerBalance) + allValidatorBalancesSummed
-		allBalances[eigenpod] = phase0.Gwei(balance)
+		allBalances[eigenpod] = phase0.Gwei(cache.PodOwnerShares[eigenpod].ExecutionLayerBalance) + allValidatorBalancesSummed
 		return allBalances
 	}, map[string]phase0.Gwei{})
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -71,7 +71,7 @@ func main() {
 						BeaconNode:            beacon,
 						Sender:                sender,
 						EigenpodAddress:       eigenpodAddress,
-						SlashedValidatorIndex: int64(slashedValidatorIndex),
+						SlashedValidatorIndex: slashedValidatorIndex,
 						Verbose:               verbose,
 						CheckpointBatchSize:   batchSize,
 						NoPrompt:              noPrompt,

--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -1,9 +1,44 @@
 package utils
 
-func ShortenHex(publicKey string) string {
-	return publicKey[0:6] + ".." + publicKey[len(publicKey)-4:]
-}
-
 // maximum number of proofs per txn for each of the following proof types:
 const DEFAULT_BATCH_CREDENTIALS = 60
 const DEFAULT_BATCH_CHECKPOINT = 80
+
+// imagine if golang had a standard library
+func Map[A any, B any](coll []A, mapper func(i A, index uint64) B) []B {
+	out := make([]B, len(coll))
+	for i, item := range coll {
+		out[i] = mapper(item, uint64(i))
+	}
+	return out
+}
+
+func Filter[A any](coll []A, criteria func(i A) bool) []A {
+	out := []A{}
+	for _, item := range coll {
+		if criteria(item) {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func Reduce[A any, B any](coll []A, processor func(accum B, next A) B, initialState B) B {
+	val := initialState
+	for _, item := range coll {
+		val = processor(val, item)
+	}
+	return val
+}
+
+func Flatten[A any](coll [][]A) []A {
+	out := []A{}
+	for _, arr := range coll {
+		out = append(out, arr...)
+	}
+	return out
+}
+
+func ShortenHex(publicKey string) string {
+	return publicKey[0:6] + ".." + publicKey[len(publicKey)-4:]
+}


### PR DESCRIPTION
- When computing the 5% deviation, we should be comparing against the balances of _all_ validators associated with the eigenpod (not just slashed ones).