### PR TITLE
`--tolerance` on `find-stale-pods`

### DIFF
--- a/cli/commands/findStalePods.go
+++ b/cli/commands/findStalePods.go
@@ -12,6 +12,7 @@ type TFindStalePodsCommandArgs struct {
 	EthNode    string
 	BeaconNode string
 	Verbose    bool
+	Tolerance  float64
 }
 
 func FindStalePodsCommand(args TFindStalePodsCommandArgs) error {
@@ -19,7 +20,7 @@ func FindStalePodsCommand(args TFindStalePodsCommandArgs) error {
 	eth, beacon, chainId, err := core.GetClients(ctx, args.EthNode, args.BeaconNode /* verbose */, args.Verbose)
 	core.PanicOnError("failed to dial clients", err)
 
-	results, err := core.FindStaleEigenpods(ctx, eth, args.EthNode, beacon, chainId, args.Verbose)
+	results, err := core.FindStaleEigenpods(ctx, eth, args.EthNode, beacon, chainId, args.Verbose, args.Tolerance)
 	core.PanicOnError("failed to find stale eigenpods", err)
 
 	if !args.Verbose {

--- a/cli/core/findStalePods.go
+++ b/cli/core/findStalePods.go
@@ -47,8 +47,6 @@ type PodOwnerShare struct {
 	IsEigenpod               bool
 }
 
-const ACCEPTABLE_BALANCE_DEVIATION = float64(0.95)
-
 var cache Cache // valid for the duration of a command.
 
 func isEigenpod(eth *ethclient.Client, chainId uint64, eigenpodAddress string) (bool, error) {
@@ -127,7 +125,7 @@ func executionWithdrawalAddress(withdrawalCredentials []byte) *string {
 	return &addr
 }
 
-func FindStaleEigenpods(ctx context.Context, eth *ethclient.Client, nodeUrl string, beacon BeaconClient, chainId *big.Int, verbose bool) (map[string][]ValidatorWithIndex, error) {
+func FindStaleEigenpods(ctx context.Context, eth *ethclient.Client, nodeUrl string, beacon BeaconClient, chainId *big.Int, verbose bool, tolerance float64) (map[string][]ValidatorWithIndex, error) {
 	beaconState, err := beacon.GetBeaconState(ctx, "head")
 	if err != nil {
 		return nil, fmt.Errorf("error downloading beacon state: %s", err.Error())
@@ -246,7 +244,7 @@ func FindStaleEigenpods(ctx context.Context, eth *ethclient.Client, nodeUrl stri
 			return false
 		}
 		executionBalance := cache.PodOwnerShares[eigenpod].SharesWei
-		if balance <= uint64(float64(executionBalance)*ACCEPTABLE_BALANCE_DEVIATION) {
+		if balance <= uint64(float64(executionBalance)*(1-tolerance)) {
 			if verbose {
 				log.Printf("[%s] %.2f%% deviation (beacon: %d -> execution: %d)\n", eigenpod, 100*(float64(executionBalance)-float64(balance))/float64(executionBalance), balance, executionBalance)
 			}
@@ -258,7 +256,7 @@ func FindStaleEigenpods(ctx context.Context, eth *ethclient.Client, nodeUrl stri
 
 	if len(unhealthyEigenpods) == 0 {
 		if verbose {
-			log.Println("All slashed eigenpods are within 5% of their expected balance.")
+			log.Printf("All slashed eigenpods are within %f%% of their expected balance.\n", tolerance)
 		}
 		return map[string][]ValidatorWithIndex{}, nil
 	}

--- a/cli/core/findStalePods.go
+++ b/cli/core/findStalePods.go
@@ -244,7 +244,7 @@ func FindStaleEigenpods(ctx context.Context, eth *ethclient.Client, nodeUrl stri
 			return false
 		}
 		executionBalance := cache.PodOwnerShares[eigenpod].SharesWei
-		if balance <= uint64(float64(executionBalance)*(1-tolerance)) {
+		if balance <= uint64(float64(executionBalance)*(1-(tolerance/100))) {
 			if verbose {
 				log.Printf("[%s] %.2f%% deviation (beacon: %d -> execution: %d)\n", eigenpod, 100*(float64(executionBalance)-float64(balance))/float64(executionBalance), balance, executionBalance)
 			}

--- a/cli/main.go
+++ b/cli/main.go
@@ -16,13 +16,15 @@ var specificValidator uint64 = math.MaxUint64
 var estimateGas = false
 var slashedValidatorIndex uint64
 
+const DEFAULT_HEALTHCHECK_TOLERANCE = float64(5.0)
+
 func main() {
 	var batchSize uint64
 	var forceCheckpoint = false
 	var disableColor = false
 	var verbose = false
 	var noPrompt = false
-	var tolerance = float64(5.0)
+	var tolerance = DEFAULT_HEALTHCHECK_TOLERANCE
 
 	app := &cli.App{
 		Name:                   "Eigenlayer Proofs CLi",
@@ -41,7 +43,7 @@ func main() {
 					BeaconNodeFlag,
 					&cli.Float64Flag{
 						Name:        "tolerance",
-						Value:       tolerance, // default: 5
+						Value:       DEFAULT_HEALTHCHECK_TOLERANCE, // default: 5
 						Usage:       "The percentage balance deviation to tolerate when deciding whether an eigenpod should be corrected. Default is 5% (e.g --tolerance 5).",
 						Destination: &tolerance,
 					},

--- a/cli/main.go
+++ b/cli/main.go
@@ -42,7 +42,7 @@ func main() {
 					&cli.Float64Flag{
 						Name:        "tolerance",
 						Value:       5,
-						Usage:       "The percentage balance deviation to tolerate when deciding whether an eigenpod should be corrected. Default is 5%.",
+						Usage:       "The percentage balance deviation to tolerate when deciding whether an eigenpod should be corrected. Default is 5% (e.g --tolerance 5).",
 						Destination: &tolerance,
 					},
 				},

--- a/cli/main.go
+++ b/cli/main.go
@@ -22,7 +22,7 @@ func main() {
 	var disableColor = false
 	var verbose = false
 	var noPrompt = false
-	var tolerance float64 = 5.0
+	var tolerance = float64(5.0)
 
 	app := &cli.App{
 		Name:                   "Eigenlayer Proofs CLi",
@@ -41,7 +41,7 @@ func main() {
 					BeaconNodeFlag,
 					&cli.Float64Flag{
 						Name:        "tolerance",
-						Value:       5,
+						Value:       tolerance, // default: 5
 						Usage:       "The percentage balance deviation to tolerate when deciding whether an eigenpod should be corrected. Default is 5% (e.g --tolerance 5).",
 						Destination: &tolerance,
 					},

--- a/cli/main.go
+++ b/cli/main.go
@@ -22,6 +22,7 @@ func main() {
 	var disableColor = false
 	var verbose = false
 	var noPrompt = false
+	var tolerance float64 = 5.0
 
 	app := &cli.App{
 		Name:                   "Eigenlayer Proofs CLi",
@@ -38,12 +39,19 @@ func main() {
 				Flags: []cli.Flag{
 					ExecNodeFlag,
 					BeaconNodeFlag,
+					&cli.Float64Flag{
+						Name:        "tolerance",
+						Value:       5,
+						Usage:       "The percentage balance deviation to tolerate when deciding whether an eigenpod should be corrected. Default is 5%.",
+						Destination: &tolerance,
+					},
 				},
 				Action: func(_ *cli.Context) error {
 					return commands.FindStalePodsCommand(commands.TFindStalePodsCommandArgs{
 						EthNode:    node,
 						BeaconNode: beacon,
 						Verbose:    verbose,
+						Tolerance:  tolerance,
 					})
 				},
 			},


### PR DESCRIPTION
`--tolerance 5` indicates that we should tolerate up to (but no more than) a 5% drop in the beacon balance before fixing the execution balance.
- Previously we defaulted to a hardcoded 5 -- this allows folks to set their own version.