### PR TITLE
Make `status` significantly faster

### DIFF
--- a/cli/core/checkpoint.go
+++ b/cli/core/checkpoint.go
@@ -187,8 +187,13 @@ func GenerateCheckpointProofForState(ctx context.Context, eigenpodAddress string
 		color.Yellow("You have a total of %d validators pointed to this pod.", len(allValidators))
 	}
 
+	allValidatorsWithInfo, err := FetchMultipleOnchainValidatorInfo(eth, eigenpodAddress, allValidators)
+	if err != nil {
+		return nil, err
+	}
+
 	tracing.OnStartSection("SelectCheckpointableValidators", map[string]string{})
-	checkpointValidators, err := SelectCheckpointableValidators(eth, eigenpodAddress, allValidators, currentCheckpointTimestamp)
+	checkpointValidators, err := SelectCheckpointableValidators(eth, eigenpodAddress, allValidatorsWithInfo, currentCheckpointTimestamp)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Summary
-  We were overfetching `GetOnchainValidatorInfo` multiple times in status, due to a regression introduced in [one of our PRs](https://github.com/Layr-Labs/eigenpod-proofs-generation/commit/26f16a4d7be67c68c799700cbba6ae3de0a1e0fc). 
- This PR changes our filtering functions to act on raw data (without fetching / side effects), and pulls our data fetching out into a separate call. This should make `status` about 60~ cheaper to run on average, in terms of network calls.
# Results 

Before: `./cli status --podAddress 0x2641C2ded63a0C640629F5eDF1189e0f53C06561      9.57s user 9.35s system 4% cpu 7:38.89 total` (458s)
After: `./cli status --podAddress 0x2641C2ded63a0C640629F5eDF1189e0f53C06561      7.24s user 6.09s system 4% cpu 4:52.41 total` (292s)

Overall about a 36% reduction in time for the command.

