### PR TITLE
Support custom `bind.CallOpts` for multicall

### DIFF
--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -335,7 +335,9 @@ func FetchMultipleOnchainValidatorInfo(ctx context.Context, client *ethclient.Cl
 	})
 
 	// make the multicall requests
-	multicallInstance, err := multicall.NewMulticallContract(ctx, client, nil, 4096 /* no batching */)
+	multicallInstance, err := multicall.NewMulticallClient(ctx, client, &multicall.TMulticallClientOptions{
+		MaxBatchSizeBytes: 4096,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to contact multicall: %s", err.Error())
 	}


### PR DESCRIPTION
- This will allow us to specify the blockNumber/blockHash at which to run the simulation.
- We need this for our indexer and in a few other places.
- Also renamed a few things in the PR.