### PR TITLE
Fix NPE in `find-stale-pods`

### DIFF
--- a/cli/core/findStalePods.go
+++ b/cli/core/findStalePods.go
@@ -194,7 +194,7 @@ func ComputeBalanceDeviationSync(ctx context.Context, eth *ethclient.Client, sta
 	})
 	PanicOnError("failed to load owner shares", err)
 
-	var sharesPendingWithdrawal *big.Int
+	var sharesPendingWithdrawal *big.Int = new(big.Int).SetUint64(0)
 	withdrawalInfo, err := delegationManager.GetQueuedWithdrawals(nil, podOwner)
 	PanicOnError("failed to load queued withdrawals", err)
 


### PR DESCRIPTION
- This should've been caught with a test, and we will be adding unit tests over most of the pieces of the CLI this year.
- Should be initialized to 0 by default. In the case where all slashed pods had pending withdrawals, this wouldnt have broken, but this is no longer the case.