### PR TITLE
[pectra] Eigenpod CLI updates

### DIFF
--- a/cli/core/findStalePods.go
+++ b/cli/core/findStalePods.go
@@ -35,7 +35,9 @@ func FracMul(a *big.Int, x *big.Int, y *big.Int) *big.Int {
 }
 
 func executionWithdrawalAddress(withdrawalCredentials []byte) *string {
-	if withdrawalCredentials[0] != 1 {
+	// after the pectra upgrade, eigenpods may be found at:
+	// 	- `0x1` or `0x2` prefixed withdrawal addresses
+	if withdrawalCredentials[0] != 1 && withdrawalCredentials[0] != 2 {
 		return nil
 	}
 	addr := common.Bytes2Hex(withdrawalCredentials[12:])
@@ -265,7 +267,7 @@ func FindStaleEigenpods(ctx context.Context, eth *ethclient.Client, nodeUrl stri
 		if !v.Validator.Slashed {
 			return false // we only care about slashed validators.
 		}
-		if v.Validator.WithdrawalCredentials[0] != 1 {
+		if v.Validator.WithdrawalCredentials[0] != 1 && v.Validator.WithdrawalCredentials[0] != 2 {
 			return false // not an execution withdrawal address
 		}
 		return true

--- a/cli/core/utils.go
+++ b/cli/core/utils.go
@@ -274,7 +274,7 @@ func FindAllValidatorsForEigenpod(eigenpodAddress string, beaconState *spec.Vers
 	maxValidators := uint64(len(allValidators))
 	for i = 0; i < maxValidators; i++ {
 		validator := allValidators[i]
-		if validator == nil || validator.WithdrawalCredentials[0] != 1 { // withdrawalCredentials _need_ their first byte set to 1 to withdraw to execution layer.
+		if validator == nil || (validator.WithdrawalCredentials[0] != 1 && validator.WithdrawalCredentials[0] != 2) { // withdrawalCredentials _need_ their first byte set to 1 or 2 to withdraw to an eigenpod on the execution layer.
 			continue
 		}
 		// we check that the last 20 bytes of expectedCredentials matches validatorCredentials.


### PR DESCRIPTION
- Everywhere we compute the set of all eigenpods, we need to take into account that `WithdrawalCredentials` can now be prefixed with `0x1` or `0x2` for eigenpods.
- Cut a new version, with updated proof code.